### PR TITLE
Rename PISM_PREFIX --> PISM_BIN

### DIFF
--- a/examples/jako/century.sh
+++ b/examples/jako/century.sh
@@ -36,11 +36,11 @@ else
 fi
 
 # prefix to pism (not to executables)
-if [ -n "${PISM_PREFIX:+1}" ] ; then  # check if env var is already set
-  echo "$SCRIPTNAME     PISM_PREFIX = $PISM_PREFIX  (already set)"
+if [ -n "${PISM_BIN:+1}" ] ; then  # check if env var is already set
+  echo "$SCRIPTNAME     PISM_BIN = $PISM_BIN  (already set)"
 else
-  PISM_PREFIX=""    # just a guess
-  echo "$SCRIPTNAME     PISM_PREFIX = $PISM_PREFIX"
+  PISM_BIN=""    # just a guess
+  echo "$SCRIPTNAME     PISM_BIN = $PISM_BIN"
 fi
 
 # set PISM_EXEC if using different executables, for example:

--- a/examples/jako/spinup.sh
+++ b/examples/jako/spinup.sh
@@ -30,11 +30,11 @@ else
 fi
 
 # prefix to pism (not to executables)
-if [ -n "${PISM_PREFIX:+1}" ] ; then  # check if env var is already set
-  echo "$SCRIPTNAME     PISM_PREFIX = $PISM_PREFIX  (already set)"
+if [ -n "${PISM_BIN:+1}" ] ; then  # check if env var is already set
+  echo "$SCRIPTNAME     PISM_BIN = $PISM_BIN  (already set)"
 else
-  PISM_PREFIX=""    # just a guess
-  echo "$SCRIPTNAME     PISM_PREFIX = $PISM_PREFIX"
+  PISM_BIN=""    # just a guess
+  echo "$SCRIPTNAME     PISM_BIN = $PISM_BIN"
 fi
 
 # set PISM_EXEC if using different executables, for example:

--- a/examples/mismip/mismip2d/README.md
+++ b/examples/mismip/mismip2d/README.md
@@ -49,7 +49,7 @@ Run in the backround with 2 cores and saving output to a text file this way:
 You can also copy the script (along with
 `MISMIP_boot_1a_M1_A1.nc` and `MISMIP_conf_1a_A*.nc`) to a supercomputer to
 do the run later.  For such application, the script helpfully uses environment variables `PISM_DO`,
-`PISM_PREFIX` and `PISM_MPIDO`. For example, on some Cray machines you might do
+`PISM_BIN` and `PISM_MPIDO`. For example, on some Cray machines you might do
 
     PISM_MPIDO="aprun -n " bash experiment-1a-mode-1.sh 32
 

--- a/examples/mismip/mismip2d/run.py
+++ b/examples/mismip/mismip2d/run.py
@@ -55,11 +55,11 @@ else
 fi
 
 # prefix to pism (not to executables)
-if [ -n "${PISM_PREFIX:+1}" ] ; then  # check if env var is already set
-  echo "$SCRIPTNAME     PISM_PREFIX = $PISM_PREFIX  (already set)"
+if [ -n "${PISM_BIN:+1}" ] ; then  # check if env var is already set
+  echo "$SCRIPTNAME     PISM_BIN = $PISM_BIN  (already set)"
 else
-  PISM_PREFIX=""    # just a guess
-  echo "$SCRIPTNAME     PISM_PREFIX = $PISM_PREFIX"
+  PISM_BIN=""    # just a guess
+  echo "$SCRIPTNAME     PISM_BIN = $PISM_BIN"
 fi
 '''
 
@@ -75,7 +75,7 @@ class Experiment:
     My = 3
     Mz = 15
     initials = "ABC"
-    executable = "$PISM_DO $PISM_MPIDO $NN ${PISM_PREFIX}pismr"
+    executable = "$PISM_DO $PISM_MPIDO $NN ${PISM_BIN}pismr"
 
     def __init__(self, experiment, model=1, mode=1, Mx=None, Mz=15, semianalytic=True,
                  initials="ABC", executable=None):

--- a/examples/relax-topography/run-relax.sh
+++ b/examples/relax-topography/run-relax.sh
@@ -45,11 +45,11 @@ else
 fi
 
 # prefix to pism (not to executables)
-if [ -n "${PISM_PREFIX:+1}" ] ; then  # check if env var is already set
-  echo "$SCRIPTNAME     PISM_PREFIX = $PISM_PREFIX  (already set)"
+if [ -n "${PISM_BIN:+1}" ] ; then  # check if env var is already set
+  echo "$SCRIPTNAME     PISM_BIN = $PISM_BIN  (already set)"
 else
-  PISM_PREFIX=""    # just a guess
-  echo "$SCRIPTNAME     PISM_PREFIX = $PISM_PREFIX"
+  PISM_BIN=""    # just a guess
+  echo "$SCRIPTNAME     PISM_BIN = $PISM_BIN"
 fi
 
 # set PISM_EXEC if using different executables, for example:
@@ -175,7 +175,7 @@ echo ""
 OCEAN="-calving ocean_kill"
 # FIXME (CK): OCEAN (above) is never used
 COUPLER="-surface given -surface_given_file $PISM_TARGETNAME"
-PISM="${PISM_PREFIX}${PISM_EXEC} -energy none -bed_def lc"
+PISM="${PISM_BIN}${PISM_EXEC} -energy none -bed_def lc"
 # output file size
 OSIZE="big"
 

--- a/examples/std-greenland/spinup.sh
+++ b/examples/std-greenland/spinup.sh
@@ -54,7 +54,7 @@ consider setting optional environment variables (see script for meaning):
     PARAM_NOSGL  if set, DON'T use -tauc_slippery_grounding_lines
     PISM_DO      set to 'echo' if no run desired; defaults to empty
     PISM_MPIDO   defaults to 'mpiexec -n'
-    PISM_PREFIX  set to path to pismr executable if desired; defaults to empty
+    PISM_BIN  set to path to pismr executable if desired; defaults to empty
     PISM_EXEC    defaults to 'pismr'
     REGRIDFILE   set to file name to regrid from; defaults to empty (no regrid)
     REGRIDVARS   desired -regrid_vars; applies *if* REGRIDFILE set;
@@ -243,11 +243,11 @@ else
 fi
 
 # prefix to pism (not to executables)
-if [ -n "${PISM_PREFIX:+1}" ] ; then  # check if env var is already set
-  echo "$SCRIPTNAME     PISM_PREFIX = $PISM_PREFIX  (already set)"
+if [ -n "${PISM_BIN:+1}" ] ; then  # check if env var is already set
+  echo "$SCRIPTNAME     PISM_BIN = $PISM_BIN  (already set)"
 else
-  PISM_PREFIX=""    # just a guess
-  echo "$SCRIPTNAME     PISM_PREFIX = $PISM_PREFIX"
+  PISM_BIN=""    # just a guess
+  echo "$SCRIPTNAME     PISM_BIN = $PISM_BIN"
 fi
 
 # set PISM_EXEC if using different executables, for example:
@@ -298,7 +298,7 @@ else
 fi
 
 # show remaining setup options:
-PISM="${PISM_PREFIX}${PISM_EXEC}"
+PISM="${PISM_BIN}${PISM_EXEC}"
 echo "$SCRIPTNAME      executable = '$PISM'"
 echo "$SCRIPTNAME         coupler = '$COUPLER'"
 echo "$SCRIPTNAME        dynamics = '$PHYS'"

--- a/examples/storglaciaren/psg_flowline.sh
+++ b/examples/storglaciaren/psg_flowline.sh
@@ -42,11 +42,11 @@ else
 fi
 
 # prefix to pism (not to executables)
-if [ -n "${PISM_PREFIX:+1}" ] ; then  # check if env var is already set
-  echo "$SCRIPTNAME     PISM_PREFIX = $PISM_PREFIX  (already set)"
+if [ -n "${PISM_BIN:+1}" ] ; then  # check if env var is already set
+  echo "$SCRIPTNAME     PISM_BIN = $PISM_BIN  (already set)"
 else
-  PISM_PREFIX=""    # just a guess
-  echo "$SCRIPTNAME     PISM_PREFIX = $PISM_PREFIX"
+  PISM_BIN=""    # just a guess
+  echo "$SCRIPTNAME     PISM_BIN = $PISM_BIN"
 fi
 
 # set PISM_EXEC if using different executables, for example:
@@ -63,7 +63,7 @@ echo
 PCONFIG=psg_config.nc
 
 # cat prefix and exec together
-PISM="${PISM_PREFIX}${PISM_EXEC} -config_override $PCONFIG -o_order zyx"
+PISM="${PISM_BIN}${PISM_EXEC} -config_override $PCONFIG -o_order zyx"
 
 
 DATANAME=storglaciaren_flowline.nc


### PR DESCRIPTION
Normally, 'PREFIX' means the root of the tree, not the bin/ directory.  I need PISM_PREFIX (or alternately, PISM_HOME) to mean the root of the tree.  This is an env var that will be used after PISM is installed, to find where it was installed.  See:
https://github.com/citibeth/spack/commit/79bb2cfc51bc142ffd2fa5eea18624cafa8d7e20

Therefore, I would like to rename PISM_PREFIX --> PISM_BIN in the scripts.