### PR TITLE
Install Examples Directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,6 +206,9 @@ install(DIRECTORY ${PROJECT_SOURCE_DIR}/util/ DESTINATION ${Pism_BIN_DIR}
   USE_SOURCE_PERMISSIONS
   FILES_MATCHING PATTERN "*.py")
 
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/examples DESTINATION ${Pism_SHARE_DIR}
+    USE_SOURCE_PERMISSIONS)
+
 add_subdirectory (src)
 add_subdirectory (site-packages)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ option (BUILD_SHARED_LIBS      "Build shared Pism libraries" ON)
 option (Pism_BUILD_PYTHON_BINDINGS "Build python bindings" OFF)
 option (Pism_BUILD_ICEBIN "Build PISM portions of IceBin library" OFF)
 option (Pism_BUILD_PDFS "Build PISM's PDF documentation with 'make all'." OFF)
+option (Pism_INSTALL_EXAMPLES "Install the example directory." OFF)
 option (Pism_USE_PROJ4 "Use Proj.4 to compute cell areas, longitudes, and latitudes." OFF)
 option (Pism_USE_PARALLEL_NETCDF4 "Enables parallel NetCDF-4 I/O." OFF)
 option (Pism_USE_PNETCDF "Enables parallel NetCDF-3 I/O using PnetCDF." OFF)
@@ -206,8 +207,11 @@ install(DIRECTORY ${PROJECT_SOURCE_DIR}/util/ DESTINATION ${Pism_BIN_DIR}
   USE_SOURCE_PERMISSIONS
   FILES_MATCHING PATTERN "*.py")
 
-install(DIRECTORY ${PROJECT_SOURCE_DIR}/examples DESTINATION ${Pism_SHARE_DIR}
+if (Pism_INSTALL_EXAMPLES)
+  install(DIRECTORY ${PROJECT_SOURCE_DIR}/examples
+    DESTINATION ${Pism_SHARE_DIR}
     USE_SOURCE_PERMISSIONS)
+endif()
 
 add_subdirectory (src)
 add_subdirectory (site-packages)


### PR DESCRIPTION
In order to decouple from a manually downloaded-and-built source directory, I would like to (optionally) install the examples directory in the PISM installation tree.  This option is turned off by default, and should have no effect on existing users who do not turn it on.
