### PR TITLE
Optionally add Everytrace to the build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ option (Pism_ADD_FPIC "Add -fPIC to C++ compiler flags (CMAKE_CXX_FLAGS). Try tu
 option (Pism_CODE_COVERAGE "Add compiler options for code coverage testing." OFF)
 option (Pism_LINK_STATICALLY "Set CMake flags to try to ensure that everything is linked statically")
 option (Pism_LOOK_FOR_LIBRARIES "Specifies whether PISM should look for libraries. (Disable this on Crays.)" ON)
+option (Pism_USE_EVERYTRACE "Use the Everytrace library to provide stacktraces on crashes." OFF)
 
 # Use rpath by default; this has to go first, because rpath settings may be overridden later.
 pism_use_rpath()
@@ -142,6 +143,10 @@ pism_set_dependencies()
 # Make sure that PetscScalar is double (not complex<double>.)
 pism_check_petsc_scalar_type()
 pism_set_version_info()
+
+if (Pism_USE_EVERYTRACE)
+  find_package(Everytrace)
+endif()
 
 if (Pism_BUILD_PYTHON_BINDINGS)
   find_package(Python REQUIRED)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -110,6 +110,7 @@ add_custom_target (touch_pism_revision
 # This library contains PISM code implementing the ice-sheet model itself
 # (using other PISM libraries and a good deal of non-trivial code).
 add_library (pism
+  ${EVERYTRACE_cf_mpi_REFADDR}
   base/pism_signal.c
   base/columnSystem.cc
   base/age/AgeModel.cc
@@ -173,7 +174,7 @@ add_library (pism
   $<TARGET_OBJECTS:pisminverse>
   $<TARGET_OBJECTS:pismregional>
 )
-target_link_libraries (pism ${Pism_EXTERNAL_LIBS})
+target_link_libraries (pism ${EVERYTRACE_LIBRARY} ${Pism_EXTERNAL_LIBS})
 add_dependencies (pism pism_config)
 add_dependencies (pism touch_pism_revision)
 

--- a/src/icebin/CMakeLists.txt
+++ b/src/icebin/CMakeLists.txt
@@ -1,6 +1,7 @@
 # PISM-side code used by IceBin (https://github.com/citibeth/icebin).
 
 add_library (pismicebin
+  ${EVERYTRACE_cf_mpi_REFADDR}
   IBIceModel.cc
   IBSurfaceModel.cc
   MassEnergyBudget.cc


### PR DESCRIPTION
This (optionally) enables the use of Everytrace with PISM.  Can be useful for debugging.  It should not affect anything for users that don't turn it on.

https://github.com/citibeth/everytrace