### PR TITLE
Add hook allowing IceModel subclasses to accumulate fluxes as needed.

### DIFF
--- a/src/base/iceModel.hh
+++ b/src/base/iceModel.hh
@@ -357,6 +357,15 @@ protected:
                                             IceModelVec2S &H,
                                             FluxCounters &fluxes_scalar,
                                             FluxFields &fluxes_2d);
+  // Hook called from within apply_surface_and_basal_mass_balance()
+  virtual void accumulateFluxes_massContExplicitStep(
+    int i, int j,
+    double surface_mass_balance,           // [m s-1] ice equivalent
+    double basal_melt_rate,                // [m s-1] ice equivalent
+    double divQ_SIA,                       // [m s-1] ice equivalent
+    double divQ_SSA,                       // [m s-1] ice equivalent
+    double Href_to_H_flux,                 // [m s-1] ice equivalent
+    double nonneg_rule_flux);               // [m s-1] ice equivalent
 
   virtual void update_grounded_cell_fraction();
   virtual void do_calving();


### PR DESCRIPTION
This change should not affect any existing code.
(This commit was transferred from an older version of PISM where things were different; some review will be required).