### PR TITLE
confused about compiler/linker errors in stable0.7 on ubuntu 17.04

### DIFF
--- a/src/base/util/Logger.cc
+++ b/src/base/util/Logger.cc
@@ -18,6 +18,7 @@
  */
 
 #include <unistd.h>
+#include <cstdarg>
 
 #include "Logger.hh"
 #include "pism_const.hh"

--- a/src/base/util/error_handling.cc
+++ b/src/base/util/error_handling.cc
@@ -21,6 +21,8 @@
 #include <petsc.h>
 
 #include <stdexcept>
+#include <cstdarg>
+
 
 namespace pism {
 

--- a/src/base/util/pism_const.cc
+++ b/src/base/util/pism_const.cc
@@ -29,6 +29,8 @@
 #include <cstdlib>
 #include <cstring>
 #include <cassert>
+#include <cstdarg>
+
 
 #include "pism_const.hh"
 #include "error_handling.hh"


### PR DESCRIPTION
On PISM branch stable0.7.  On ubuntu 17.04 with current petsc master (https://bitbucket.org/petsc/petsc/commits/d04c6f677f3122cd2f1a1920704de39c2d23c350?at=master).

These `#include`s resolve errors about missing `va_start`, `va_end`.

But I only get part way through the PISM build and then hit
```
~/pism/build0.7[stable0.7*]$ make
[  2%] Built target pismcalcalcs
[  3%] Generating pism_config.nc
[  3%] Built target pism_config
Scanning dependencies of target pismutil
[  4%] Building CXX object src/CMakeFiles/pismutil.dir/base/util/pism_const.cc.o
/home/ed/pism/src/base/util/pism_const.cc: In function ‘void pism::verbPrintf(int, MPI_Comm, const char*, ...)’:
/home/ed/pism/src/base/util/pism_const.cc:88:54: error: ‘PetscVFPrintf’ was not declared in this scope
       ierr = PetscVFPrintf(PETSC_STDOUT, format, Argp);
                                                      ^
src/CMakeFiles/pismutil.dir/build.make:1046: recipe for target 'src/CMakeFiles/pismutil.dir/base/util/pism_const.cc.o' failed
make[2]: *** [src/CMakeFiles/pismutil.dir/base/util/pism_const.cc.o] Error 1
CMakeFiles/Makefile2:1297: recipe for target 'src/CMakeFiles/pismutil.dir/all' failed
make[1]: *** [src/CMakeFiles/pismutil.dir/all] Error 2
Makefile:138: recipe for target 'all' failed
make: *** [all] Error 2
```
Changing to `PetscVFPrintfDefault()` does not help.
