### PR TITLE
Add two-dimensional sub-shelf basal mass flux offset modifier

### DIFF
--- a/doc/sphinx/climate_forcing/ocean.rst
+++ b/doc/sphinx/climate_forcing/ocean.rst
@@ -193,6 +193,7 @@ PICO has one command-line option and 7 configuration parameters:
 - :config:`ocean.pico.maximum_ice_rise_area`: specifies an area threshold that separates
   ice rises from continental regions.
 
+
 .. _sec-ocean-delta-sl:
 
 Scalar sea level offsets
@@ -296,6 +297,24 @@ It takes the following command-line options:
   model years; see section :ref:`sec-periodic-forcing`.
 - :opt:`-ocean_frac_SMB_reference_year` specifies the reference date; see section
   :ref:`sec-periodic-forcing`.
+
+.. _sec-ocean-delta-smb-2d:
+
+Two-dimensional sub-shelf mass flux offsets (PICO)
+++++++++++++++++++++++++++++++++++++++++++++++++++
+
+:|options|: ``-initmip_bmb_anomaly``
+:|variables|: :var:`bmb_anomaly` |flux|
+:|implementation|: ``pism::ocean::Pico``
+
+This modifier implements forcing using two-dimensioal sub-shelf mass flux (melt rate) offsets 
+for the purpose model intercomparison (such as LARMIP),
+
+It takes the following command-line options:
+
+- :opt:`-ocean_pico_file`: specifies the NetCDF file containing sub-shelf mass flux anomaly (:var:`bmb_anomaly`).
+
+So far, this modifier is only available for the PICO ocean coupler.
 
 .. _sec-ocean-frac-mbp:
 

--- a/doc/sphinx/climate_forcing/ocean.rst
+++ b/doc/sphinx/climate_forcing/ocean.rst
@@ -193,7 +193,6 @@ PICO has one command-line option and 7 configuration parameters:
 - :config:`ocean.pico.maximum_ice_rise_area`: specifies an area threshold that separates
   ice rises from continental regions.
 
-
 .. _sec-ocean-delta-sl:
 
 Scalar sea level offsets
@@ -298,23 +297,32 @@ It takes the following command-line options:
 - :opt:`-ocean_frac_SMB_reference_year` specifies the reference date; see section
   :ref:`sec-periodic-forcing`.
 
-.. _sec-ocean-delta-smb-2d:
+.. _sec-ocean-anomaly:
 
-Two-dimensional sub-shelf mass flux offsets (PICO)
-++++++++++++++++++++++++++++++++++++++++++++++++++
+Two-dimensional sub-shelf mass flux offsets
++++++++++++++++++++++++++++++++++++++++++++
 
-:|options|: ``-initmip_bmb_anomaly``
-:|variables|: :var:`bmb_anomaly` |flux|
-:|implementation|: ``pism::ocean::Pico``
+:|options|: :opt:`-ocean ...,anomaly`
+:|variables|: :var:`shelf_base_mass_flux_anomaly` |flux|
+:|implementation|: ``pism::ocean::Anomaly``
 
-This modifier implements forcing using two-dimensioal sub-shelf mass flux (melt rate) offsets 
-for the purpose model intercomparison (such as LARMIP),
+This modifier implements a spatially-variable version of ``-ocean ...,delta_T`` which
+also applies time-dependent shelf base mass flux anomalies, as used for initMIP or LARMIP
+model intercomparisons.
 
 It takes the following command-line options:
 
-- :opt:`-ocean_pico_file`: specifies the NetCDF file containing sub-shelf mass flux anomaly (:var:`bmb_anomaly`).
+- :opt:`-ocean_anomaly_file` specifies a file containing variables
+  :var:`shelf_base_mass_flux_anomaly`.
+- :opt:`-ocean_anomaly_period` (years) specifies the period of the forcing data, in
+  model years; see :ref:`sec-periodic-forcing`
+- :opt:`-ocean_anomaly_reference_year` specifies the reference year; see
+  :ref:`sec-periodic-forcing`
 
-So far, this modifier is only available for the PICO ocean coupler.
+  See also to ``-atmosphere ...,anomaly`` or 
+  ``-surface ...,anomaly`` (section :ref:`sec-surface-anomaly`)
+  which is similar, but applies anomalies at the atmosphere or surface level, 
+  respectively.
 
 .. _sec-ocean-frac-mbp:
 

--- a/doc/sphinx/climate_forcing/ocean.rst
+++ b/doc/sphinx/climate_forcing/ocean.rst
@@ -306,22 +306,22 @@ Two-dimensional sub-shelf mass flux offsets
 :|variables|: :var:`shelf_base_mass_flux_anomaly` |flux|
 :|implementation|: ``pism::ocean::Anomaly``
 
-This modifier implements a spatially-variable version of ``-ocean ...,delta_T`` which
-also applies time-dependent shelf base mass flux anomalies, as used for initMIP or LARMIP
+This modifier implements a spatially-variable version of ``-ocean ...,delta_SMB`` which
+applies time-dependent shelf base mass flux anomalies, as used for initMIP or LARMIP
 model intercomparisons.
 
 It takes the following command-line options:
 
-- :opt:`-ocean_anomaly_file` specifies a file containing variables
+- :opt:`-ocean_anomaly_file` specifies a file containing the variable
   :var:`shelf_base_mass_flux_anomaly`.
 - :opt:`-ocean_anomaly_period` (years) specifies the period of the forcing data, in
   model years; see :ref:`sec-periodic-forcing`
 - :opt:`-ocean_anomaly_reference_year` specifies the reference year; see
   :ref:`sec-periodic-forcing`
 
-  See also to ``-atmosphere ...,anomaly`` or 
+  See also to ``-atmosphere ...,anomaly`` or
   ``-surface ...,anomaly`` (section :ref:`sec-surface-anomaly`)
-  which is similar, but applies anomalies at the atmosphere or surface level, 
+  which is similar, but applies anomalies at the atmosphere or surface level,
   respectively.
 
 .. _sec-ocean-frac-mbp:

--- a/doc/sphinx/manual/parameters/parameter-list.txt
+++ b/doc/sphinx/manual/parameters/parameter-list.txt
@@ -1164,6 +1164,24 @@
    :Option: :opt:`-tikhonov_rtol`
    :Description: relative threshold for Tikhonov stopping criterion
 
+#. :config:`ocean.anomaly.file` (*string*)
+
+   :Value: *no default*
+   :Option: :opt:`-ocean_anomaly_file`
+   :Description: Name of the file containing shelf basal mass flux offset fields.
+
+#. :config:`ocean.anomaly.period` (*integer*)
+
+   :Value: 0
+   :Option: :opt:`-ocean_anomaly_period`
+   :Description: Length of the period of the ocean forcing data. Set to zero to disable.
+
+#. :config:`ocean.anomaly.reference_year` (*integer*)
+
+   :Value: 0
+   :Option: :opt:`-ocean_anomaly_reference_year`
+   :Description: Reference year to use when ``ocean.anomaly.period`` is active.
+
 #. :config:`ocean.given.file` (*string*)
 
    :Value: *no default*

--- a/src/coupler/CMakeLists.txt
+++ b/src/coupler/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library (boundary OBJECT
   ./ocean/Constant.cc
   ./ocean/GivenClimate.cc
   ./ocean/GivenTH.cc
+  ./ocean/Anomaly.cc
   ./ocean/Delta_T.cc
   ./ocean/Delta_SMB.cc
   ./ocean/Frac_MBP.cc

--- a/src/coupler/ocean/Anomaly.cc
+++ b/src/coupler/ocean/Anomaly.cc
@@ -1,0 +1,96 @@
+// Copyright (C) 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018 PISM Authors
+//
+// This file is part of PISM.
+//
+// PISM is free software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the Free Software
+// Foundation; either version 3 of the License, or (at your option) any later
+// version.
+//
+// PISM is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+// details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PISM; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+#include "Anomaly.hh"
+#include "pism/util/IceGrid.hh"
+#include "pism/util/io/io_helpers.hh"
+#include "pism/coupler/util/options.hh"
+
+namespace pism {
+namespace ocean {
+
+Anomaly::Anomaly(IceGrid::ConstPtr g, std::shared_ptr<OceanModel> in)
+  : OceanModel(g, in) {
+
+  ForcingOptions opt(*m_grid->ctx(), "ocean.anomaly");
+
+  {
+    unsigned int buffer_size = m_config->get_double("climate_forcing.buffer_size");
+    unsigned int evaluations_per_year = m_config->get_double("climate_forcing.evaluations_per_year");
+    bool periodic = opt.period > 0;
+
+    PIO file(m_grid->com, "netcdf3", opt.filename, PISM_READONLY);
+
+    m_shelf_base_mass_flux_anomaly = IceModelVec2T::ForcingField(m_grid,
+                                                                  file,
+                                                                  "shelf_base_mass_flux_anomaly",
+                                                                  "", // no standard name
+                                                                  buffer_size,
+                                                                  evaluations_per_year,
+                                                                  periodic);
+  }
+
+  m_shelf_base_mass_flux_anomaly->set_attrs("climate_forcing",
+                                             "anomaly of the shelf base mass flux rate",
+                                             "kg m-2 s-1", "");
+  m_shelf_base_mass_flux_anomaly->metadata().set_string("glaciological_units", "kg m-2 year-1");
+
+  m_shelf_base_mass_flux = allocate_shelf_base_mass_flux(g);
+
+
+}
+
+Anomaly::~Anomaly() {
+  // empty
+}
+
+void Anomaly::init_impl(const Geometry &geometry) {
+
+  if (m_input_model) {
+    m_input_model->init(geometry);
+  }
+
+  m_log->message(2,
+                 "* Initializing the '-ocean ...,anomaly' modifier...\n");
+
+  ForcingOptions opt(*m_grid->ctx(), "ocean.anomaly");
+
+  m_log->message(2,
+                 "    reading anomalies from %s ...\n", opt.filename.c_str());
+
+  m_shelf_base_mass_flux_anomaly->init(opt.filename, opt.period, opt.reference_time);
+}
+
+void Anomaly::update_impl(const Geometry &geometry, double t, double dt) {
+  m_input_model->update(geometry, t, dt);
+
+  m_shelf_base_mass_flux_anomaly->update(t, dt);
+
+  m_shelf_base_mass_flux_anomaly->average(t, dt);
+
+  m_input_model->shelf_base_mass_flux().add(1.0, *m_shelf_base_mass_flux_anomaly,
+                                 *m_shelf_base_mass_flux);
+}
+
+const IceModelVec2S &Anomaly::shelf_base_mass_flux_impl() const {
+  return *m_shelf_base_mass_flux;
+}
+
+
+} // end of namespace ocean
+} // end of namespace pism

--- a/src/coupler/ocean/Anomaly.hh
+++ b/src/coupler/ocean/Anomaly.hh
@@ -17,7 +17,7 @@
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #ifndef _POANOMALY_H_
-#define _POANOMALY_H
+#define _POANOMALY_H_
 
 #include "pism/coupler/OceanModel.hh"
 #include "pism/util/iceModelVec2T.hh"

--- a/src/coupler/ocean/Anomaly.hh
+++ b/src/coupler/ocean/Anomaly.hh
@@ -1,0 +1,50 @@
+// Copyright (C) 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018 PISM Authors
+//
+// This file is part of PISM.
+//
+// PISM is free software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the Free Software
+// Foundation; either version 3 of the License, or (at your option) any later
+// version.
+//
+// PISM is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+// details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PISM; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+#ifndef _POANOMALY_H_
+#define _POANOMALY_H
+
+#include "pism/coupler/OceanModel.hh"
+#include "pism/util/iceModelVec2T.hh"
+
+namespace pism {
+namespace ocean {
+
+//! @brief Reads and uses shelf_basal_mass_flux *anomalies* from a file
+class Anomaly : public OceanModel
+{
+public:
+  Anomaly(IceGrid::ConstPtr g, std::shared_ptr<OceanModel> in);
+  virtual ~Anomaly();
+protected:
+  virtual void init_impl(const Geometry &geometry);
+  virtual void update_impl(const Geometry &geometry, double t, double dt);
+
+  virtual const IceModelVec2S& shelf_base_mass_flux_impl() const;
+
+protected:
+  IceModelVec2S::Ptr m_shelf_base_mass_flux;
+
+  IceModelVec2T::Ptr m_shelf_base_mass_flux_anomaly;
+
+};
+
+} // end of namespace ocean
+} // end of namespace pism
+
+#endif /* _POANOMALY_H_ */

--- a/src/coupler/ocean/Factory.cc
+++ b/src/coupler/ocean/Factory.cc
@@ -20,6 +20,7 @@
 #include "Factory.hh"
 
 // ocean models:
+#include "Anomaly.hh"
 #include "Constant.hh"
 #include "ConstantPIK.hh"
 #include "GivenClimate.hh"
@@ -46,6 +47,7 @@ Factory::Factory(IceGrid::ConstPtr g)
   add_model<Given>("given");
   set_default("constant");
 
+  add_modifier<Anomaly>("anomaly");
   add_modifier<Cache>("cache");
   add_modifier<Delta_SMB>("delta_SMB");
   add_modifier<Frac_SMB>("frac_SMB");

--- a/src/coupler/ocean/Pico.cc
+++ b/src/coupler/ocean/Pico.cc
@@ -40,6 +40,7 @@
 #include "pism/util/Time.hh"
 #include "pism/geometry/Geometry.hh"
 
+#include "pism/util/pism_options.hh"
 #include "pism/coupler/util/options.hh"
 
 #include "Pico.hh"
@@ -76,6 +77,19 @@ Pico::Pico(IceGrid::ConstPtr g)
                                                    buffer_size,
                                                    evaluations_per_year,
                                                    periodic);
+
+
+
+    larmip_bmb_anomaly = options::Bool("-initmip_bmb_anomaly", "add basal melt rate anomaly to PICO melt rates"); 
+    if (larmip_bmb_anomaly){
+       bmb_anomaly = IceModelVec2T::ForcingField(m_grid,
+                                                 file,
+                                                 "bmb_anomaly",
+                                                 "", // no standard name
+                                                 buffer_size,
+                                                 evaluations_per_year,
+                                                 periodic);
+    }
   }
 
   m_theta_ocean->set_attrs("climate_forcing",
@@ -85,6 +99,13 @@ Pico::Pico(IceGrid::ConstPtr g)
   m_salinity_ocean->set_attrs("climate_forcing",
                               "salinity of the adjacent ocean",
                               "g/kg", "");
+
+  // read a bmb_anomaly field from a file..
+  if (larmip_bmb_anomaly){
+    bmb_anomaly->set_attrs("climate_forcing",
+                           "basal mass balance anomaly for LARMIP Antarctica experiments",
+                           "kg m-2 year-1", "");
+  }
 
   m_basin_mask.create(m_grid, "basins", WITH_GHOSTS);
   m_basin_mask.set_attrs("climate_forcing", "mask determines basins for PICO", "", "");
@@ -145,6 +166,12 @@ void Pico::init_impl(const Geometry &geometry) {
   m_theta_ocean->init(opt.filename, opt.period, opt.reference_time);
   m_salinity_ocean->init(opt.filename, opt.period, opt.reference_time);
 
+  if (larmip_bmb_anomaly){
+    bmb_anomaly->init(opt.filename, opt.period, opt.reference_time);  
+    //*bmb_anomaly = units::convert(m_sys, bmb_anomaly, "m year-1","m second-1");
+    //bmb_anomaly->scale(cc.rhoi);
+  }
+
   m_basin_mask.regrid(opt.filename, CRITICAL);
 
   // FIXME: m_n_basins is a misnomer
@@ -196,6 +223,11 @@ void Pico::update_impl(const Geometry &geometry, double t, double dt) {
 
   m_theta_ocean->average(t, dt);
   m_salinity_ocean->average(t, dt);
+
+  if (larmip_bmb_anomaly){
+    bmb_anomaly->update(t, dt); 
+    bmb_anomaly->average(t, dt);  
+  }
 
   // set values that will be used outside of floating ice areas
   {
@@ -281,8 +313,44 @@ void Pico::update_impl(const Geometry &geometry, double t, double dt) {
   m_shelf_base_mass_flux->copy_from(m_basal_melt_rate);
   m_shelf_base_mass_flux->scale(physics.ice_density());
 
+  /////////////////////////////////////////////////////////////////////////////
+  if (larmip_bmb_anomaly){
+    m_log->message(5, "!!!!! meltrate anomaly from file added to PICO result \n");
+    add_bmb_anomaly(cell_type,
+                    *bmb_anomaly,
+                    *m_shelf_base_mass_flux);
+  }
+
+  // only used for test purposes...
+  bool no_shelfb_melt = options::Bool("-no_shelfb_melt","Sets shelfbmassflux to 0.0");
+  if (no_shelfb_melt) {
+     m_log->message(5, "!!!!! Setting PICO basal mass flux to 0.0 \n");
+     m_shelf_base_mass_flux->set(0.0);
+  }
+  /////////////////////////////////////////////////////////////////////////////
+
   m_melange_back_pressure_fraction->set(0.0);
 }
+
+
+void Pico::add_bmb_anomaly(const IceModelVec2CellType &cell_type,
+                           const IceModelVec2S &bmassflux_anomaly,
+                           IceModelVec2S &bmassflux){
+
+    IceModelVec::AccessList list{ &bmassflux, &cell_type, &bmassflux_anomaly};
+
+    for (Points p(*m_grid); p; p.next()) {
+      const int i = p.i(), j = p.j();
+      if (cell_type.as_int(i,j) == MASK_FLOATING) {
+
+        double mrate_anomaly = units::convert(m_sys, bmassflux_anomaly(i,j), "m year-1","m second-1");
+        bmassflux(i,j) +=  mrate_anomaly;
+      }
+    }
+}
+
+
+
 
 MaxTimestep Pico::max_timestep_impl(double t) const {
   (void) t;

--- a/src/coupler/ocean/Pico.hh
+++ b/src/coupler/ocean/Pico.hh
@@ -57,11 +57,13 @@ private:
   IceModelVec2S m_overturning;
   IceModelVec2S m_basal_melt_rate;
 
+  bool larmip_bmb_anomaly;
+
   IceModelVec2Int m_basin_mask;
 
   std::unique_ptr<PicoGeometry> m_geometry;
 
-  IceModelVec2T::Ptr m_theta_ocean, m_salinity_ocean;
+  IceModelVec2T::Ptr m_theta_ocean, m_salinity_ocean, bmb_anomaly;
 
   void compute_ocean_input_per_basin(const PicoPhysics &physics,
                                      const IceModelVec2Int &basin_mask,
@@ -126,6 +128,11 @@ private:
                         const IceModelVec2Int &shelf_mask,
                         const IceModelVec2Int &box_mask,
                         std::vector<double> &result);
+
+  void add_bmb_anomaly(const IceModelVec2CellType &cell_type,
+                       const IceModelVec2S &bmassflux_anomaly,
+                       IceModelVec2S &bmassflux);
+                       
 
   int m_n_basins, m_n_boxes, m_n_shelves;
 };

--- a/src/coupler/ocean/Pico.hh
+++ b/src/coupler/ocean/Pico.hh
@@ -57,13 +57,11 @@ private:
   IceModelVec2S m_overturning;
   IceModelVec2S m_basal_melt_rate;
 
-  bool larmip_bmb_anomaly;
-
   IceModelVec2Int m_basin_mask;
 
   std::unique_ptr<PicoGeometry> m_geometry;
 
-  IceModelVec2T::Ptr m_theta_ocean, m_salinity_ocean, bmb_anomaly;
+  IceModelVec2T::Ptr m_theta_ocean, m_salinity_ocean;
 
   void compute_ocean_input_per_basin(const PicoPhysics &physics,
                                      const IceModelVec2Int &basin_mask,
@@ -129,10 +127,6 @@ private:
                         const IceModelVec2Int &box_mask,
                         std::vector<double> &result);
 
-  void add_bmb_anomaly(const IceModelVec2CellType &cell_type,
-                       const IceModelVec2S &bmassflux_anomaly,
-                       IceModelVec2S &bmassflux);
-                       
 
   int m_n_basins, m_n_boxes, m_n_shelves;
 };

--- a/src/pism_config.cdl
+++ b/src/pism_config.cdl
@@ -1100,6 +1100,23 @@ netcdf pism_config {
     pism_config:inverse.tikhonov.rtol_type = "scalar";
     pism_config:inverse.tikhonov.rtol_units = "1";
 
+    pism_config:ocean.anomaly.file = "";
+    pism_config:ocean.anomaly.file_doc = "Name of the file containing shelf basal mass flux offset fields.";
+    pism_config:ocean.anomaly.file_type = "string";
+    pism_config:ocean.anomaly.file_option = "ocean_anomaly_file";
+
+    pism_config:ocean.anomaly.period = 0;
+    pism_config:ocean.anomaly.period_doc = "Length of the period of the ocean forcing data. Set to zero to disable.";
+    pism_config:ocean.anomaly.period_type = "integer";
+    pism_config:ocean.anomaly.period_option = "ocean_anomaly_period";
+    pism_config:ocean.anomaly.period_units = "years";
+
+    pism_config:ocean.anomaly.reference_year = 0;
+    pism_config:ocean.anomaly.reference_year_doc = "Reference year to use when ``ocean.anomaly.period`` is active.";
+    pism_config:ocean.anomaly.reference_year_option = "ocean_anomaly_reference_year";
+    pism_config:ocean.anomaly.reference_year_type = "integer";
+    pism_config:ocean.anomaly.reference_year_units = "years";
+
     pism_config:ocean.given.file = "";
     pism_config:ocean.given.file_doc = "Name of the file containing climate forcing fields.";
     pism_config:ocean.given.file_type = "string";

--- a/src/pythonbindings/pism_ocean.i
+++ b/src/pythonbindings/pism_ocean.i
@@ -3,6 +3,7 @@
 #include "coupler/ocean/Cache.hh"
 #include "coupler/ocean/ConstantPIK.hh"
 #include "coupler/ocean/Delta_SMB.hh"
+#include "coupler/ocean/Anomaly.hh"
 #include "coupler/ocean/Delta_T.hh"
 #include "coupler/ocean/Frac_SMB.hh"
 #include "coupler/ocean/Frac_MBP.hh"
@@ -36,6 +37,10 @@
 %shared_ptr(pism::ocean::Delta_SMB)
 %rename(OceanDeltaSMB) pism::ocean::Delta_SMB;
 %include "coupler/ocean/Delta_SMB.hh"
+
+%shared_ptr(pism::ocean::Anomaly)
+%rename(OceanAnomaly) pism::ocean::Anomaly;
+%include "coupler/ocean/Anomaly.hh"
 
 %shared_ptr(pism::ocean::Delta_T)
 %rename(OceanDeltaT) pism::ocean::Delta_T;

--- a/test/regression/ocean_models.py
+++ b/test/regression/ocean_models.py
@@ -310,6 +310,37 @@ class DeltaSMB(TestCase):
     def tearDown(self):
         os.remove(self.filename)
 
+class AnomalyBMB(TestCase):
+    def setUp(self):
+        self.filename = "delta_BMB_input.nc"
+        self.grid = dummy_grid()
+        self.geometry = create_geometry(self.grid)
+        self.model = PISM.OceanConstant(self.grid)
+        self.dBMB = -5.0
+
+        delta_BMB = PISM.IceModelVec2S(self.grid, "shelf_base_mass_flux_anomaly",
+                                       PISM.WITHOUT_GHOSTS)
+        delta_BMB.set_attrs("climate_forcing",
+                            "2D shelf base mass flux anomaly", "kg m-2 s-1", "")
+        delta_BMB.set(self.dBMB)
+
+        delta_BMB.dump(self.filename)
+
+    def runTest(self):
+        "Modifier Anomaly"
+
+        config.set_string("ocean.anomaly.file", self.filename)
+
+        modifier = PISM.OceanAnomaly(self.grid, self.model)
+
+        modifier.init(self.geometry)
+        modifier.update(self.geometry, 0, 1)
+
+        check_modifier(self.model, modifier, 0.0, self.dBMB, 0.0)
+
+    def tearDown(self):
+        os.remove(self.filename)
+
 class FracMBP(TestCase):
     def setUp(self):
         self.filename = "frac_MBP_input.nc"


### PR DESCRIPTION
As some model intercomparisons like LARMIP request such a regional offset, this has been implemented to PICO for now, but could be added as a general modifier (after the PICO calculations have been completed).