### PR TITLE
Modified conversion factor in sea-level equivalent

### DIFF
--- a/doc/ice-bib.bib
+++ b/doc/ice-bib.bib
@@ -789,6 +789,15 @@ note = {doi: 10.5194/gmd-8-1613-2015}
       YEAR = {2001},
 }
 
+@article{Cogley2011,
+    title = {Glossary of glacier mass balance and related terms},
+   author = {Cogley, JG and Hock, R and Rasmussen, LA and Arendt, AA and Bauder, A and Braithwaite, RJ and Jansson, P and Kaser, G and M{\"o}ller, M and Nicholson, L and others},
+  journal = {IHP-VII technical documents in hydrology},
+   volume = {86},
+    pages = {965},
+     year = {2011}
+}
+
 
 @article {ColingeRappaz,
     AUTHOR = {Colinge, Jacques and Rappaz, Jacques},

--- a/doc/sphinx/manual/practical-usage/saving-time-series.rst
+++ b/doc/sphinx/manual/practical-usage/saving-time-series.rst
@@ -97,11 +97,13 @@ several scalar diagnostics:
   grid parameters, and the WGS84 reference ellipsoid. This yields areas and volumes with
   greater accuracy.
 
-- The sea-level-relevant ice volume ``slvol`` is the total grounded ice volume minus the
-  amount of ice, that, in liquid form, would fill up the regions with bedrock below sea
-  level, if this ice were removed. That is, ``slvol`` is the sea level rise potential of
-  the ice sheet at that time. The result is reported in sea-level equivalent, i.e. meters
-  of sea level rise.
+- The sea-level-relevant ice volume ``slvol`` is the total grounded ice volume above flotation, 
+  following here the definition in SeaRISE :cite:`Bindschadler2013SeaRISE`. Basically it represents 
+  the amount of ice, that, if it were melted, would fill up the ocean with a surface area 
+  of :math:`362.5 \times 10^6 km^2` :cite:`Cogley2011`. That is, ``slvol`` is the sea level rise 
+  potential of the ice sheet at that time. This neglects the ice at buoyancy that already replaces 
+  the corresponding ocean volume. The result is reported in sea-level equivalent, i.e. 
+  meters of global mean sea level rise.
 
 - Fields ``max_diffusivity`` and ``max_hor_vel`` relate to PISM time-stepping. These
   quantities appear in per-time-step form in the standard output from PISM (i.e. at

--- a/src/icemodel/diagnostics.cc
+++ b/src/icemodel/diagnostics.cc
@@ -2700,14 +2700,14 @@ double IceModel::ice_volume_not_displacing_seawater(double thickness_threshold) 
 //! Computes the ice volume, which is relevant for sea-level rise in m^3 in SEA-WATER EQUIVALENT.
 double IceModel::sealevel_volume(double thickness_threshold) const {
   const double
-    sea_water_density = m_config->get_double("constants.sea_water.density"),
-    ice_density       = m_config->get_double("constants.ice.density");
+    water_density = m_config->get_double("constants.fresh_water.density"),
+    ice_density   = m_config->get_double("constants.ice.density"),
+    ocean_area    = m_config->get_double("constants.sea_water.surface_area");
 
   const double
-    ocean_area = 3.61e14, // units: meter^2
     volume = ice_volume_not_displacing_seawater(thickness_threshold),
-    sea_water_volume = (ice_density / sea_water_density) * volume, // corresponding sea water volume
-    sea_level_change = sea_water_volume / ocean_area;
+    additional_water_volume = (ice_density / water_density) * volume, // corresponding sea water volume
+    sea_level_change = additional_water_volume / ocean_area;
 
   return sea_level_change;
 }

--- a/src/pism_config.cdl
+++ b/src/pism_config.cdl
@@ -487,6 +487,11 @@ netcdf pism_config {
     pism_config:constants.sea_water.specific_heat_capacity_type = "scalar";
     pism_config:constants.sea_water.specific_heat_capacity_units = "Joule / (kg Kelvin)";
 
+    pism_config:constants.sea_water.surface_area = 3.625e14;
+    pism_config:constants.sea_water.surface_area_doc = "surface area of ocean after Cogley et al., 2011";
+    pism_config:constants.sea_water.surface_area_type = "scalar";
+    pism_config:constants.sea_water.surface_area_units = "`meter^{2}`";
+
     pism_config:constants.standard_gravity = 9.81;
     pism_config:constants.standard_gravity_doc = "acceleration due to gravity on Earth geoid";
     pism_config:constants.standard_gravity_type = "scalar";


### PR DESCRIPTION
ice volume calculation. This refers to the discussions in #412 and should make PISM-produced `slvol `timeseries diagnostic consistent with other model outputs. For present-day Antarctica (Bedmap2) this fix should now state 58.20 m SLE instead of 56.85 m SLE.