### PR TITLE
Limit sia diffusivity instead of cancel run

### DIFF
--- a/src/pism_config.cdl
+++ b/src/pism_config.cdl
@@ -1498,6 +1498,11 @@ netcdf pism_config {
     pism_config:stress_balance.sia.grain_size_age_coupling_option = "grain_size_age_coupling";
     pism_config:stress_balance.sia.grain_size_age_coupling_type = "boolean";
 
+    pism_config:stress_balance.sia.bound_by_max_diffusivity = "no";
+    pism_config:stress_balance.sia.bound_by_max_diffusivity_doc = "Bound SIA diffusivity by upper bound";
+    pism_config:stress_balance.sia.bound_by_max_diffusivity_option = "limit_sia_diffusivity";
+    pism_config:stress_balance.sia.bound_by_max_diffusivity_type = "boolean";
+
     pism_config:stress_balance.sia.max_diffusivity = 100.0;
     pism_config:stress_balance.sia.max_diffusivity_doc = "Maximum allowed diffusivity of the SIA flow. PISM stops with an error message if the SIA diffusivity exceeds this limit.";
     pism_config:stress_balance.sia.max_diffusivity_type = "scalar";

--- a/src/stressbalance/sia/SIAFD.cc
+++ b/src/stressbalance/sia/SIAFD.cc
@@ -32,7 +32,6 @@
 #include "pism/util/IceModelVec2CellType.hh"
 #include "pism/geometry/Geometry.hh"
 #include "pism/stressbalance/StressBalance.hh"
-//#include "pism/util/pism_options.hh"
 
 #include "pism/util/Time.hh"
 
@@ -578,17 +577,9 @@ void SIAFD::compute_diffusivity(bool full_update,
   const bool use_age = compute_grain_size_using_age or e_age_coupling;
 
   // Introduces upper bound for maximum diffusivity which determines maximum timestep
-  // Caution: May violate conservation laws
+  // Caution: May violate conservation laws?
   const double m_D_max_opt = m_config->get_double("stress_balance.sia.max_diffusivity");
   const bool D_max_from_option_set = m_config->get_boolean("stress_balance.sia.bound_by_max_diffusivity");
-
-  //const double D_max_from_option = m_config->get_double("D_max_from_option");
-  //bool D_max_from_option_set;
-  //options::Real y("-D_max_from_option", "Upper limit for SIA diffusivity", m_config->get_double("D_max_from_option"));
-  //if (D_max_from_option_set) {
-  //  m_log->message(2,"!!!! Dmax_diffuse set: %.2f\n",D_max_from_option);
-  //}
-
 
   // get "theta" from Schoof (2003) bed smoothness calculation and the
   // thickness relative to the smoothed bed; each IceModelVec2S involved must
@@ -776,7 +767,6 @@ void SIAFD::compute_diffusivity(bool full_update,
                      "This probably means that the bed elevation or the ice thickness is too rough.\n"
                      "SIA diffusivity is bounded by maximum value %.2f\n",
                      m_D_max_opt);
-    //m_D_max = m_D_max_opt;
   }
 }
 


### PR DESCRIPTION
There has been an upper limit for the SIA diffusivity implemented as option since commit bf76acb7227836. For certain experiments (e.g. float_kill) SIA diffusivities can be large for a short moment and now those runs are killed. For such experiments it would be helpful to avoid canceling the job but to use the upper limit of SIA diffusivity to also avoid extremely small adaptive time steps. However, I have no clue about the implications in terms of energy or mass conservation?