### PR TITLE
Limit in SSA velocity magnitude within iterations

### DIFF
--- a/src/pism_config.cdl
+++ b/src/pism_config.cdl
@@ -1590,6 +1590,12 @@ netcdf pism_config {
     pism_config:stress_balance.ssa.fd.replace_zero_diagonal_entries_doc = "Replace zero diagonal entries in the SSAFD matrix with basal_resistance.beta_ice_free_bedrock to avoid solver failures.";
     pism_config:stress_balance.ssa.fd.replace_zero_diagonal_entries_type = "boolean";
 
+    pism_config:stress_balance.ssa.fd.max_vel = 5.0e3;
+    pism_config:stress_balance.ssa.fd.max_vel_doc = "Upper bound for SSA velocity magnitude";
+    pism_config:stress_balance.ssa.fd.max_vel_type = "scalar";
+    pism_config:stress_balance.ssa.fd.max_vel_units = "m yr-1";
+    pism_config:stress_balance.ssa.fd.max_vel_option = "limit_ssa_velocity";
+
     pism_config:stress_balance.ssa.flow_law = "gpbld";
     pism_config:stress_balance.ssa.flow_law_choices = "arr,arrwarm,gpbld,hooke,isothermal_glen,pb,gpbld3";
     pism_config:stress_balance.ssa.flow_law_doc = "The SSA flow law.";


### PR DESCRIPTION
As we at PIK have often seen in simulations of the Antarctic Ice Sheet unrealistically high SSA velocities (often just in single grid points), which lead to convergence problems (causing an increasing regularization parameter) and additional iterations (affecting also the rest of the velocity field), as well as to short adaptive timesteps (due to CFL criterion). 

This pull request adds an option (`-limit_ssa_velocity 5e3`) to avoid unrealistically high SSA velocities and short timesteps, even though it may not be the right place in the code to help with convergence problems (additional options as `-ssa_rtol 5e-4` may be needed). This allows also for `-no_mass` simulations including SSA stress balance for a more realistic initial temperature/enthalpy distribution in particular at the ice sheet fringes. 

**I would like to discuss here with other users their experience on this issue** and whether or not such an option could be helpful or should be better avoided in terms of physics or numerics?!

For a first impression on the effect of this option in full-dynamic simulations, see plots [here](https://nbviewer.jupyter.org/url/www.pik-potsdam.de/~albrecht/notebooks/check_ssa_speed_limit.ipynb).
