### PR TITLE
Add a CONTRIBUTING.md?  Use the content at pism-docs.org or change?

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+For now, see http://www.pism-docs.org/wiki/doku.php?id=committing


### PR DESCRIPTION
I could move the content at http://www.pism-docs.org/wiki/doku.php?id=committing to here.  I think this is a good idea so as to reduce weight at un-backed-up pism-docs.org.  (Among other reasons, like raising our "community" rating at github.)