### PR TITLE
Add installation instructions for Arch Linux

### DIFF
--- a/doc/sphinx/global.txt
+++ b/doc/sphinx/global.txt
@@ -46,6 +46,7 @@
 
 .. external links
 
+.. _Arch Linux User Repository: https://aur.archlinux.org
 .. _Bash: http://www.gnu.org/software/bash/
 .. _CalCalcs: http://meteora.ucsd.edu/~pierce/calcalcs/calendars.html
 .. _CalCalcs-home: http://meteora.ucsd.edu/~pierce/calcalcs/index.html
@@ -76,6 +77,7 @@
 .. _NetCDF: https://www.unidata.ucar.edu/software/netcdf/
 .. _netcdf-classic-format: https://www.unidata.ucar.edu/software/netcdf/docs/file_structure_and_performance.html#classic_file_parts
 .. _NumPy: http://www.numpy.org/
+.. _Open MPI: https://www.open-mpi.org
 .. _PETSc-installation: https://www.mcs.anl.gov/petsc/documentation/installation.html
 .. _PETSc: https://www.mcs.anl.gov/petsc/
 .. _PROJ.4: https://proj4.org/

--- a/doc/sphinx/global.txt
+++ b/doc/sphinx/global.txt
@@ -46,7 +46,6 @@
 
 .. external links
 
-.. _Arch Linux User Repository: https://aur.archlinux.org
 .. _Bash: http://www.gnu.org/software/bash/
 .. _CalCalcs: http://meteora.ucsd.edu/~pierce/calcalcs/calendars.html
 .. _CalCalcs-home: http://meteora.ucsd.edu/~pierce/calcalcs/index.html

--- a/doc/sphinx/installation/arch.rst
+++ b/doc/sphinx/installation/arch.rst
@@ -1,10 +1,12 @@
+.. include:: ../global.txt
+
 .. _sec-install-arch:
 
-Installing prerequisites and build PISM on Arch Linux
------------------------------------------------------
+Installing prerequisites and building PISM on Arch Linux
+--------------------------------------------------------
 
 PISM is registered as a `package <https://aur.archlinux.org/packages/pism/>`_
-in the `Arch Linux User Repository`_ (AUR). This package will build the latest
+in the `Arch Linux User Repository <https://aur.archlinux.org>`_ (AUR). This package will build the latest
 PISM release and its dependencies. PISM is linked to `Open MPI`_ and is
 installed under ``/usr``.
 
@@ -13,6 +15,7 @@ such as `yay <https://aur.archlinux.org/packages/yay/>`_. If you do not already
 have an AUR helper installed, install ``yay`` with the following commands:
 
 .. code-block:: bash
+   
    git clone https://aur.archlinux.org/yay.git
    cd git
    makepkg -si
@@ -20,6 +23,7 @@ have an AUR helper installed, install ``yay`` with the following commands:
 You can then install PISM and its dependencies with the following command:
 
 .. code-block:: bash
+   
    yay -Sy pism
 
 Once installed, the PISM binaries (e.g. ``pismr``, ``pisms``, various Python

--- a/doc/sphinx/installation/arch.rst
+++ b/doc/sphinx/installation/arch.rst
@@ -1,0 +1,28 @@
+.. _sec-install-arch:
+
+Installing prerequisites and build PISM on Arch Linux
+-----------------------------------------------------
+
+PISM is registered as a `package <https://aur.archlinux.org/packages/pism/>`_
+in the `Arch Linux User Repository`_ (AUR). This package will build the latest
+PISM release and its dependencies. PISM is linked to `Open MPI`_ and is
+installed under ``/usr``.
+
+Installation from the AUR requires an `AUR helper <https://wiki.archlinux.org/index.php/AUR_helpers>`_
+such as `yay <https://aur.archlinux.org/packages/yay/>`_. If you do not already
+have an AUR helper installed, install ``yay`` with the following commands:
+
+.. code-block:: bash
+   git clone https://aur.archlinux.org/yay.git
+   cd git
+   makepkg -si
+
+You can then install PISM and its dependencies with the following command:
+
+.. code-block:: bash
+   yay -Sy pism
+
+Once installed, the PISM binaries (e.g. ``pismr``, ``pisms``, various Python
+tools) are available in the PATH and do not require further intervention to
+work. It is recommended that the installation is manually verified with the
+instructions in section :ref:`sec-install-quick-tests`.

--- a/doc/sphinx/installation/cookbook.rst
+++ b/doc/sphinx/installation/cookbook.rst
@@ -12,6 +12,7 @@ cases; please `e-mail us <pism-email_>`_ if you need help.
 .. toctree::
 
    debian.rst
+   arch.rst
    macos.rst
    sources.rst
 

--- a/doc/sphinx/installation/index.rst
+++ b/doc/sphinx/installation/index.rst
@@ -6,9 +6,10 @@ Installing PISM
 +++++++++++++++
 
 The fastest path to a fully functional PISM installation is to use a Linux system with a
-Debian-based package system (e.g. Ubuntu_): Start by following subsection
-:ref:`sec-install-debian`, then :ref:`sec-install-petsc`, then :ref:`sec-install-pism` to
-install PISM itself.
+Debian- or Arch Linux-based package system (e.g. Ubuntu_): In Debian and derivatives,
+start by following subsection :ref:`sec-install-debian`, then :ref:`sec-install-petsc`,
+then :ref:`sec-install-pism` to install PISM itself. In Arch Linux and derivatives,
+follow the instructions in subsection :ref:`sec-install-arch`.
 
 .. toctree::
 


### PR DESCRIPTION
This PR adds instructions on how to install PISM and its dependencies on Arch Linux, a process that is increadibly easy thanks to Julien Seguinot's [AUR package for PISM](https://aur.archlinux.org/packages/pism/).

I am not sure how you feel about inline hyperlinks, but I felt most of the Arch Linux-specific external references would *probably* not be relevant outside of the section. Let me know if you feel otherwise.

In closing, I have complete understanding if you do not want to clutter the docs with install instructions for every distro, so feel free to reject.