### PR TITLE
Fix inconsistency between pico and subgl_melt

### DIFF
--- a/src/coupler/ocean/Pico.hh
+++ b/src/coupler/ocean/Pico.hh
@@ -103,6 +103,8 @@ private:
                            IceModelVec2S &T_star,
                            IceModelVec2S &Toc,
                            IceModelVec2S &Soc);
+  void extend_basal_melt_rates(const IceModelVec2CellType &mask,
+                          IceModelVec2S &basal_melt_rate); 
 
   void beckmann_goosse(const PicoPhysics &physics,
                        const IceModelVec2S &ice_thickness,


### PR DESCRIPTION
Pico melt rates are extended into the neighboring grounded cells to make sure that melt rates are also applied in partially grounded cells when using -subgl_basal_melt. Note that those melt rates are not accounted for in the module.