### PR TITLE
Rounding reported MaxTimestep to the next lower whole second.

### DIFF
--- a/src/util/MaxTimestep.cc
+++ b/src/util/MaxTimestep.cc
@@ -17,6 +17,8 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+#include <cmath>
+
 #include "MaxTimestep.hh"
 
 namespace pism {
@@ -28,7 +30,7 @@ MaxTimestep::MaxTimestep()
 }
 
 MaxTimestep::MaxTimestep(double v)
-  : m_finite(true), m_value(v) {
+  : m_finite(true), m_value(std::floor(v)) {
   // empty
 }
 
@@ -38,7 +40,7 @@ MaxTimestep::MaxTimestep(const std::string &new_description)
 }
 
 MaxTimestep::MaxTimestep(double v, const std::string &new_description)
-  : m_finite(true), m_value(v), m_description(new_description) {
+  : m_finite(true), m_value(std::floor(v)), m_description(new_description) {
   // empty
 }
 


### PR DESCRIPTION
The changes suggested in this pull request address issue #407.

Adding floating point numbers introduce rounding errors in the last digits, which will accumulate and be amplified by other model feedbacks. This introduces a dependence on the start date of a model run. 
These errors are omitted when the timestep is rounded to the next whole lower number. 