### PR TITLE
replaced time.clock() as it is deprecated in python3.8

### DIFF
--- a/examples/python/ssa_forward.py
+++ b/examples/python/ssa_forward.py
@@ -24,6 +24,7 @@ import time
 # The main code for a run follows:
 if __name__ == '__main__':
     context = PISM.Context()
+    config = context.config
     com = context.com
 
     PISM.set_abort_on_sigint(True)
@@ -54,9 +55,9 @@ if __name__ == '__main__':
 
     ssa_run.setup()
 
-    solve_t0 = time.clock()
+    solve_t0 = time.time()
     vel_ssa = ssa_run.solve()
-    solve_t = time.clock() - solve_t0
+    solve_t = time.time() - solve_t0
 
     PISM.verbPrintf(2, context.com, "Solve time %g seconds.\n", solve_t)
 


### PR DESCRIPTION
minor change in python example for SSA forward solver:
replaced time.clock() with time.time() as the former is deprecated in python3.8


**Checklist**

- [ ] update documentation
- [ ] update [`CHANGES.rst`](CHANGES.rst)
- [ ] add regression tests
