### PR TITLE
Remove assert T_s to be positive in PicoPhysics.cc

### DIFF
--- a/src/coupler/ocean/PicoPhysics.cc
+++ b/src/coupler/ocean/PicoPhysics.cc
@@ -174,12 +174,7 @@ double PicoPhysics::overturning(double Soc_box0, double Soc, double Toc_box0, do
 //! See equation A6 and lines before in PICO paper
 double PicoPhysics::T_star(double salinity, double temperature, double pressure) const {
   double T_s = theta_pm(salinity, pressure) - temperature; // in Kelvin
-
-  // Positive values are unphysical as temperatures below the pressure melting point would
-  // be ice, but we are in the ocean. This should not occur because
-  // set_ocean_input_fields(...) sets too cold temperatures to pressure melting point +
-  // 0.001
-  return std::min(T_s, 0.0);
+  return T_s;
 }
 
 //! calculate p coefficent for solving the quadratic temperature equation


### PR DESCRIPTION
See discussion in #454. Otherwise PICO refreezing rates can be drastically overestimated.