### PR TITLE
Add time_stepping.resolution (default: 1 second)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,9 +45,9 @@ Changes since v1.2
   Blatter (1995). This solver supports multigrid preconditioners (see Brown et al 2013)
   and includes 5 verification test based on manufactured solutions.
 - Implement experiments A,B,C,D,E from the ISMIP-HOM intercomparison.
-- Adjust PICO ocean input average across covered basins, in which the ice shelf has 
-  in fact a connection to the ocean. Large ice shelves, that cover across two basins, 
-  that do not share an ocean boundary, are split into two separate ice shelf instances 
+- Adjust PICO ocean input average across covered basins, in which the ice shelf has
+  in fact a connection to the ocean. Large ice shelves, that cover across two basins,
+  that do not share an ocean boundary, are split into two separate ice shelf instances
 - Implement scaling of calving rates using a time-dependent factor. Set
   `calving.rate_scaling.file` to the name of the file containing `frac_calving_rate`
   (units: "1").
@@ -64,6 +64,9 @@ Changes since v1.2
   parameters use units of `365 days` instead of `years`. The latter has the meaning of the
   mean tropical year, i.e. the constant used to convert from `1/s` to `1/year`. Use `-y
   1000years`, etc to reproduce the old behavior.
+- Add a new parameter: `time_stepping.resolution`. PISM rounds time step lengths *down* to
+  a multiple of this number (default: 1 second). This reduces the influence of rounding
+  errors on time step lengths. See `issue 407`_.
 
 Changes from v1.1 to v1.2
 =========================
@@ -884,6 +887,7 @@ Miscellaneous
 .. _issue 405: https://github.com/pism/pism/issues/405
 .. _issue 422: https://github.com/pism/pism/issues/422
 .. _issue 424: https://github.com/pism/pism/issues/424
+.. _issue 407: https://github.com/pism/pism/issues/407
 .. _ocean models: http://pism-docs.org/sphinx/climate_forcing/ocean.html
 ..
    Local Variables:

--- a/doc/sphinx/manual/practical-usage/time-stepping.rst
+++ b/doc/sphinx/manual/practical-usage/time-stepping.rst
@@ -103,6 +103,29 @@ step length.
    PISM will take a 9 model year long time step. This can be useful to enforce consistent
    sampling of periodic climate data.
 
+#. If the value `R` set using :config:`time_stepping.resolution` is positive PISM
+   reduces the time step length so that
+
+   .. math::
+      :label: eq-dt-rounding-down
+
+      \dt = N\cdot R
+
+   for some integer `N`.
+
+   The default `R` (`1` second) allows PISM to represent model time more accurately,
+   reducing the influence of rounding errors.
+
+   .. note::
+
+      This is an intermediate-term solution for an issue reported by Thomas Kleiner:
+      some simulations produced different results with identical inputs but *different*
+      start years.
+
+      We tracked it down to the fact that these simulations ended up using slightly
+      different time step lengths. This, in turn, was caused by differences in the
+      *absolute* precision of the C++ type ``double`` for numbers of different magnitudes.
+
 #. The time step length never exceeds the total length of the run.
 
 At each time step the PISM standard output includes "flags" and then a summary of the

--- a/src/pism_config.cdl
+++ b/src/pism_config.cdl
@@ -2735,6 +2735,11 @@ netcdf pism_config {
     pism_config:time_stepping.maximum_time_step_type = "number";
     pism_config:time_stepping.maximum_time_step_units = "365day";
 
+    pism_config:time_stepping.resolution = 1.0;
+    pism_config:time_stepping.resolution_doc = "Time steps are rounded down to be a multiple of this number (set to zero to allow arbitrary time step lengths)";
+    pism_config:time_stepping.resolution_type = "number";
+    pism_config:time_stepping.resolution_units = "seconds";
+
     pism_config:time_stepping.skip.enabled = "no";
     pism_config:time_stepping.skip.enabled_doc = "Use the temperature, age, and SSA stress balance computation skipping mechanism.";
     pism_config:time_stepping.skip.enabled_option = "skip";

--- a/test/regression/test_15.sh
+++ b/test/regression/test_15.sh
@@ -10,8 +10,8 @@ output=`mktemp pism-test-C.XXXX` || exit 1
 
 # run test C
 OPTS="-test C -Mbz 1 -Mz 31 -y 5000years -o_size none -verbose 1 -max_dt 60years"
-$PISM_PATH/pismv -Mx 31 -My 31 $OPTS  > ${output}
-$PISM_PATH/pismv -Mx 41 -My 41 $OPTS >> ${output}
+$MPIEXEC -n 4 $PISM_PATH/pismv -Mx 31 -My 31 $OPTS  > ${output}
+$MPIEXEC -n 4 $PISM_PATH/pismv -Mx 41 -My 41 $OPTS >> ${output}
 
 # compare results
 diff ${output} -  <<END-OF-OUTPUT

--- a/test/regression/test_17.sh
+++ b/test/regression/test_17.sh
@@ -9,9 +9,9 @@ echo "Test #17: verif test G regression: thermo SIA w. time-dependent SMB."
 output=`mktemp pism-test-G.XXXX` || exit 1
 
 # run test G
-OPTS="-test G -Mbz 1 -Mz 31 -y 1000years -max_dt 60years -o_size none -verbose 1"
-$PISM_PATH/pismv -Mx 31 -My 31 $OPTS   > ${output}
-$PISM_PATH/pismv -Mx 41 -My 41 $OPTS  >> ${output}
+OPTS="-test G -Mbz 1 -Mz 31 -y 1000years -max_dt 60years -o_size none -verbose 1 -time_stepping.resolution 0"
+$MPIEXEC -n 4 $PISM_PATH/pismv -Mx 31 -My 31 $OPTS   > ${output}
+$MPIEXEC -n 4 $PISM_PATH/pismv -Mx 41 -My 41 $OPTS  >> ${output}
 
 # compare results
 diff ${output} -  <<END-OF-OUTPUT

--- a/test/regression/test_18.sh
+++ b/test/regression/test_18.sh
@@ -10,7 +10,7 @@ echo "Test #18: verif test K regression: cold ice method, bedrock thermal layer.
 output=`mktemp pism-test-k.XXXX` || exit 1
 
 # run test K
-OPTS="-test K -Mx 4 -My 4 -y 13000.0years -Lbz 1000 -z_spacing equal -verbose 1 -o_size none"
+OPTS="-test K -Mx 4 -My 4 -y 13000.0years -Lbz 1000 -z_spacing equal -verbose 1 -o_size none -time_stepping.resolution 0"
 $PISM_PATH/pismv -Mz 41 -Mbz 11 -max_dt 60.0years $OPTS  > ${output}
 $PISM_PATH/pismv -Mz 81 -Mbz 21 -max_dt 30.0years $OPTS >> ${output}
 


### PR DESCRIPTION
Add a new configuration parameter `time_stepping.resolution`. If set to a positive number (in seconds), PISM will round time step lengths down to a multiple of this number, _unless_ this gives zero.

This increases the likelihood of being able to represent model time *exactly* in the C++ data type `double` and avoid the influence of limited floating point precision on model results (see #407). This PR replaces #458.

- [x] update documentation
- [x] update [`CHANGES.rst`](CHANGES.rst)
- [x] add regression tests (new tests are not needed)

The script below uses a synthetic geometry setup from `examples/marine/circular` to reproduce the issue (try this with the current `dev` branch) and confirm that this change improves matters.

``` bash
#!/bin/bash

set -u
set -e

## Path to the input file
input_file=~/github/pism/pism/examples/marine/circular/circular_withshelf.nc
# PISM's installation path
pism_path=~/local/pism/bin
pismr="$pism_path/pismr"

# run duration
run_length=1000

results=$PWD/results

mkdir -p $results

grid="-periodicity none -Mx 61 -My 61 -Lz 5500 -Mz 3"

options="-sia_e 2.0 -atmosphere given -surface given -ocean pik -meltfactor_pik 5e-3 "
options="$options -max_dt 10 -bed_def lc -bed_deformation.lc.update_interval 10"
options="$options -ssa_method fd -ssa_e 0.55 -pik -stress_balance ssa+sia"
options="$options -calving eigen_calving,thickness_calving -eigen_calving_k 1.0e17 -thickness_calving_threshold 150.0"
options="$options -pseudo_plastic -pseudo_plastic_q 0.6 -till_effective_fraction_overburden 0.02"
options="$options -topg_to_phi 10.0,30.0,-700.0,200.0 -hydrology null"
options="$options -ts_times yearly"
options="$options -options_left -verbose 2 -o_size big -calendar 365_day"

## same as -pik
options="$options -cfbc -kill_icebergs -part_grid -subgl"
options="$options -tauc_slippery_grounding_lines "

run() {
start=$1
suffix=$2

out=o_${suffix}.nc
ts=ts_${suffix}.nc

mpiexec -n 4 ${pismr} ${options} \
       -i $input_file \
       -o $results/$out \
       -ts_file ${results}/$ts \
       -y ${run_length} \
       -bootstrap ${grid} \
       -ys ${start}
}

compare() {
suffix1=$1
suffix2=$2

## check 1
for var in topg dbdt thk ;
do
  ncdiff -O -v $var $results/o_${suffix1}.nc $results/o_${suffix2}.nc $results/diff_${var}.nc
done

## check 2
python3 $pism_path/nccmp.py -v topg,thk \
        ${results}/o_${suffix1}.nc \
        ${results}/o_${suffix2}.nc | tee ${results}/nccmp.log
}

## start at year 0
run 0 r1

## start at year 100000
run 100000 r2

## compare results
compare r1 r2
```