### PR TITLE
Implement M* as an SIA option in addition to our Mahaffy schemes

### DIFF
--- a/src/pism_config.cdl
+++ b/src/pism_config.cdl
@@ -2215,7 +2215,7 @@ netcdf pism_config {
     pism_config:stress_balance.sia.max_diffusivity_units = "m2 s-1";
 
     pism_config:stress_balance.sia.surface_gradient_method = "haseloff";
-    pism_config:stress_balance.sia.surface_gradient_method_choices = "eta,haseloff,mahaffy";
+    pism_config:stress_balance.sia.surface_gradient_method_choices = "eta,haseloff,mahaffy,mstar";
     pism_config:stress_balance.sia.surface_gradient_method_doc = "method used for surface gradient calculation at staggered grid points";
     pism_config:stress_balance.sia.surface_gradient_method_option = "gradient";
     pism_config:stress_balance.sia.surface_gradient_method_type = "keyword";

--- a/src/stressbalance/sia/SIAFD.cc
+++ b/src/stressbalance/sia/SIAFD.cc
@@ -159,8 +159,6 @@ void SIAFD::update(const IceModelVec2V &sliding_velocity,
     compute_diffusive_flux(m_h_x, m_h_y, m_D, m_diffusive_flux);
   }
   profiling.end("sia.flux");
-  // DEBUG
-  m_diffusive_flux.dump("diffusive_flux.nc");
 
   if (full_update) {
     profiling.begin("sia.3d_velocity");

--- a/src/stressbalance/sia/SIAFD.cc
+++ b/src/stressbalance/sia/SIAFD.cc
@@ -31,6 +31,7 @@
 #include "pism/util/pism_utilities.hh"
 #include "pism/util/Profiling.hh"
 #include "pism/util/IceModelVec2CellType.hh"
+#include "pism/util/fem/FEM.hh"   // for mstar stuff below
 #include "pism/geometry/Geometry.hh"
 #include "pism/stressbalance/StressBalance.hh"
 
@@ -138,10 +139,15 @@ void SIAFD::update(const IceModelVec2V &sliding_velocity,
   }
 
   profiling.begin("sia.gradient");
+  // FIXME if stress_balance.sia.surface_gradient_method == mstar then the
+  //   following returns the mahaffy version, thus in conflict with result
+  //   of compute_diffusive_flux_mstar() below
   compute_surface_gradient(inputs, m_h_x, m_h_y);
   profiling.end("sia.gradient");
 
   profiling.begin("sia.flux");
+  // FIXME if stress_balance.sia.surface_gradient_method == mstar then the
+  //   following generates an m_D which is ignored by compute_diffusive_flux_mstar() below
   compute_diffusivity(full_update,
                       *inputs.geometry,
                       inputs.enthalpy,
@@ -804,61 +810,77 @@ void SIAFD::compute_diffusive_flux(const IceModelVec2Stag &h_x, const IceModelVe
   } // o-loop
 }
 
-double SIAFD::q_mstar(const double H, const double slope, const double gradscomponent) {
+double SIAFD::q_mstar(const double H, const double slopemag, const double ds) {
   const double n   = m_flow_law->exponent(), // presumably 3.0
                g   = m_config->get_number("constants.standard_gravity"),
                rho = m_config->get_number("constants.ice.density"),
                A   = m_config->get_number("flow_law.Paterson_Budd.A_cold"),
                Gamma = 2.0 * A * pow(rho * g, n) / (n + 2.0);
 
-  return - Gamma * pow(H, n + 2.0) * pow(slope, n - 1.0) * gradscomponent;
+  return - Gamma * pow(H, n + 2.0) * pow(slopemag, n - 1.0) * ds;
 }
 
+// FIXME test of this new code:
+//    pismv -test B -ys 422.45 -y 1 -gradient mstar
+// compare
+//    pismv -test B -ys 422.45 -y 1 -gradient mahaffy
 void SIAFD::compute_diffusive_flux_mstar(const Geometry &geometry,
                                          IceModelVec2Stag &result) {
 
-  const double dx  = m_grid->dx(), dy  = m_grid->dy();
-
+  using fem::QuadPoint;
+  using fem::Germ;
+  using fem::q1::n_chi;
+  using fem::q1::chi;
+  const double dx = m_grid->dx(), dy = m_grid->dy();
   const IceModelVec2S &s = geometry.ice_surface_elevation,
                       &H = geometry.ice_thickness;
-
   IceModelVec::AccessList list{&s, &H, &result};
+  /* offset of element vertex from lower-left corner
+       3 o-----o 2
+         |     |
+         |     |
+       0 o-----o 1    */
+  const unsigned int voff[n_chi][2] = {{0, 0},
+                                       {1, 0},
+                                       {1, 1},
+                                       {0, 1}};
+  // we use quadrature points from Bueler 2016 Figure 3, which have the
+  // following locations in the [-1,1]x[-1,1] reference element
+  const QuadPoint qp[4] = {{ 0.0, -0.5, 0.0},  // point 0 in Figure 3; up pt on right face of control
+                           { 0.0,  0.5, 0.0},  // point 7; down pt on right face of control
+                           {-0.5,  0.0, 0.0},  // point 1; right pt on top face of control
+                           { 0.5,  0.0, 0.0}}; // point 2; left pt on top face of control
 
   ParallelSection loop(m_grid->com);
   try {
     for (PointsWithGhosts p(*m_grid); p; p.next()) {
-      const int i = p.i(), j = p.j();
-      for (int o = 0; o < 2; o++) {
-        // apply equation (25) in Bueler 2016, or similar, to each face of the
-        //   control rectangle; in fact we only do top and right faces
-        // note _up,_down are quadrature points 0,7 in Bueler 2016 Figure 3,
-        //   while _left,_right are 2,1
-        double qint = 0.0; // estimate of integral of flux along face
-        if (o == 0) {
-          // next lines use equation (18) in Bueler 2016
-          double sx_up = ((s(i + 1, j) - s(i, j)) * 0.75 + (s(i + 1, j + 1) - s(i, j + 1)) * 0.25) / dx,
-                 sy_up = ((s(i, j + 1) - s(i, j)) * 0.5  + (s(i + 1, j + 1) - s(i + 1, j)) * 0.5 ) / dy,
-                 slope_up = sqrt(PetscSqr(sx_up) + PetscSqr(sy_up));
-          double H_up = 0.0; // FIXME
-          double q_up = q_mstar(H_up, slope_up, sx_up),
-                 q_down = 0.0; // FIXME
-          qint = (dy / 2.0) * (q_up + q_down);
-        } else {
-          double q_left = 0.0, // FIXME
-                 q_right = 0.0; // FIXME
-          qint = (dx / 2.0) * (q_left + q_right);
+      const int i = p.i(), j = p.j();  // regular grid point at (i,j)
+      // apply equation (25) in Bueler 2016, or similar, to top and right
+      //   faces of the control rectangle centered at regular point (i,j)
+      for (int o = 0; o < 2; o++) { // o==0 is right face, o==1 is top face
+        double q[2]; // value of flux at each quadrature point
+        // next lines use equation (18) in Bueler 2016
+        for (unsigned int l = 0; l < 2; l++) { // two quadrature points per face
+          double HH, sx, sy = 0.0;
+          for (unsigned int k = 0; k < n_chi; k++) { // four vertices of Q1 element
+            const int ei = i - l * o, ej = j - l * (1-o);  // which element
+            const Germ &psi = chi(k, qp[l]); // germ of shape function at quad point
+            HH += psi.val * H(ei + voff[k][0], ej + voff[k][1]);
+            const double sk = s(ei + voff[k][0], ej + voff[k][1]);
+            sx += psi.dx * sk / dx;
+            sy += psi.dy * sk / dy;
+          }
+          const double slopemag = sqrt(PetscSqr(sx) + PetscSqr(sy));
+          q[l] = q_mstar(HH, slopemag, (o == 0) ? sx : sy);
         }
         // result is average flux over the face of the control rectangle
-        result(i, j, o) = qint / ((o == 0) ? dy : dx);
+        result(i, j, o) = 0.5 * (q[0] + q[1]);
       } // o-loop
     }
   } catch (...) {
     loop.failed();
   }
   loop.check();
-
-  throw RuntimeError::formatted(PISM_ERROR_LOCATION,
-                                "compute_diffusive_flux_mstar() is not implemented");
 }
 
 //! \brief Compute I.

--- a/src/stressbalance/sia/SIAFD.cc
+++ b/src/stressbalance/sia/SIAFD.cc
@@ -160,6 +160,8 @@ void SIAFD::update(const IceModelVec2V &sliding_velocity,
   }
   profiling.end("sia.flux");
 
+  m_diffusive_flux.dump("diffusive_flux.nc");  // DEBUG
+
   if (full_update) {
     profiling.begin("sia.3d_velocity");
     compute_3d_horizontal_velocity(*inputs.geometry, m_h_x, m_h_y, sliding_velocity,
@@ -923,12 +925,12 @@ void SIAFD::compute_diffusive_flux_mstar(const Geometry &geometry,
       // NW element
       double q2{0.0};
       {
-        NE.reset(i - 1, j);
-        NE.nodal_values(ice_thickness, H);
-        NE.nodal_values(ice_surface, S);
+        NW.reset(i - 1, j);
+        NW.nodal_values(ice_thickness, H);
+        NW.nodal_values(ice_surface, S);
 
-        NE.evaluate(H, Hq);
-        NE.evaluate(S, s, sx, sy);
+        NW.evaluate(H, Hq);
+        NW.evaluate(S, s, sx, sy);
 
         q2 = q_mstar(Hq[0], sx[0], sy[0]).v;
       }

--- a/src/stressbalance/sia/SIAFD.cc
+++ b/src/stressbalance/sia/SIAFD.cc
@@ -814,11 +814,14 @@ void SIAFD::compute_diffusive_flux(const IceModelVec2Stag &h_x, const IceModelVe
 
 // compute formula (2) in Bueler 2016
 Vector2 SIAFD::q_mstar(double H, double sx, double sy) {
+  // See FIXME comments below: this will break for flow laws other than isothermal_glen.
   const double
     n        = m_flow_law->exponent(), // presumably 3.0
     g        = m_config->get_number("constants.standard_gravity"),
     rho      = m_config->get_number("constants.ice.density"),
-    A        = m_config->get_number("flow_law.Paterson_Budd.A_cold"),
+    E        = 0.0,             // FIXME
+    p        = 0.0,             // FIXME
+    A        = m_flow_law->softness(E, p),
     Gamma    = 2.0 * A * pow(rho * g, n) / (n + 2.0),
     slopemag = sqrt(sx * sx + sy * sy);
 

--- a/src/stressbalance/sia/SIAFD.cc
+++ b/src/stressbalance/sia/SIAFD.cc
@@ -160,8 +160,6 @@ void SIAFD::update(const IceModelVec2V &sliding_velocity,
   }
   profiling.end("sia.flux");
 
-  m_diffusive_flux.dump("diffusive_flux.nc");  // DEBUG
-
   if (full_update) {
     profiling.begin("sia.3d_velocity");
     compute_3d_horizontal_velocity(*inputs.geometry, m_h_x, m_h_y, sliding_velocity,

--- a/src/stressbalance/sia/SIAFD.cc
+++ b/src/stressbalance/sia/SIAFD.cc
@@ -817,6 +817,7 @@ Vector2 SIAFD::q_mstar(double H, double sx, double sy) {
   // See FIXME comments below: this will break for flow laws other than isothermal_glen.
   const double
     n        = m_flow_law->exponent(), // presumably 3.0
+    // FIXME: m_config->get_...() should not be used here (it is slow)
     g        = m_config->get_number("constants.standard_gravity"),
     rho      = m_config->get_number("constants.ice.density"),
     E        = 0.0,             // FIXME

--- a/src/stressbalance/sia/SIAFD.hh
+++ b/src/stressbalance/sia/SIAFD.hh
@@ -93,6 +93,12 @@ protected:
                                       const IceModelVec2Stag &diffusivity,
                                       IceModelVec2Stag &result);
 
+  virtual double q_mstar(const double H, const double slope,
+                         const double gradscomponent);
+
+  virtual void compute_diffusive_flux_mstar(const Geometry &geometry,
+                                            IceModelVec2Stag &result);
+
   virtual void compute_3d_horizontal_velocity(const Geometry &geometry,
                                               const IceModelVec2Stag &h_x,
                                               const IceModelVec2Stag &h_y,

--- a/src/stressbalance/sia/SIAFD.hh
+++ b/src/stressbalance/sia/SIAFD.hh
@@ -93,9 +93,12 @@ protected:
                                       const IceModelVec2Stag &diffusivity,
                                       IceModelVec2Stag &result);
 
+  virtual Vector2 W_mstar(double sx, double sy,
+                          double bx, double by);
+
   virtual Vector2 q_mstar(double H, double Hx, double Hy,
                           double sx, double sy,
-                          double bx, double by);
+                          Vector2 W, double Hup);
 
   virtual void compute_diffusive_flux_mstar(const Geometry &geometry,
                                             IceModelVec2Stag &result);

--- a/src/stressbalance/sia/SIAFD.hh
+++ b/src/stressbalance/sia/SIAFD.hh
@@ -93,7 +93,9 @@ protected:
                                       const IceModelVec2Stag &diffusivity,
                                       IceModelVec2Stag &result);
 
-  virtual Vector2 q_mstar(double H, double sx, double sy);
+  virtual Vector2 q_mstar(double H, double Hx, double Hy,
+                          double sx, double sy,
+                          double bx, double by);
 
   virtual void compute_diffusive_flux_mstar(const Geometry &geometry,
                                             IceModelVec2Stag &result);

--- a/src/stressbalance/sia/SIAFD.hh
+++ b/src/stressbalance/sia/SIAFD.hh
@@ -93,8 +93,7 @@ protected:
                                       const IceModelVec2Stag &diffusivity,
                                       IceModelVec2Stag &result);
 
-  virtual double q_mstar(const double H, const double slope,
-                         const double gradscomponent);
+  virtual Vector2 q_mstar(double H, double sx, double sy);
 
   virtual void compute_diffusive_flux_mstar(const Geometry &geometry,
                                             IceModelVec2Stag &result);


### PR DESCRIPTION
This draft PR is, for now, intended to start a conversation.

See https://doi.org/10.1017/jog.2015.3 for the paper where the M* scheme for the SIA is described.  I hope that the scheme may remove some of the high-frequency chatter (checkerboard) seen in e.g. Thomas Franks' SIA results.  

Our existing schemes for SIA fluxes all arise from Mahaffy, though different surface gradient calculations are implemented.  Note there are two advantages of M*: better quadrature, upwinding of the advective part of the SIA flux (when the bed is nonflat).  I am starting by just trying to implement the better quadrature.

**Checklist**

- [ ] update documentation
- [ ] update [`CHANGES.rst`](CHANGES.rst)
- [ ] add regression tests
