### PR TITLE
Fix: thickness calving does not work with constant threshold in dev branch

### DIFF
--- a/src/frontretreat/calving/CalvingAtThickness.cc
+++ b/src/frontretreat/calving/CalvingAtThickness.cc
@@ -24,6 +24,7 @@
 #include "pism/util/pism_utilities.hh"
 #include "pism/coupler/util/options.hh"
 #include "pism/util/iceModelVec2T.hh"
+#include "pism/util/io/File.hh"
 
 namespace pism {
 
@@ -70,7 +71,9 @@ void CalvingAtThickness::init() {
 
   ForcingOptions opt(*m_grid->ctx(), "calving.thickness_calving");
 
-  if (not opt.filename.empty()) {
+  File file(m_grid->com, opt.filename, PISM_GUESS, PISM_READONLY);
+  auto variable_exists = file.find_variable(m_calving_threshold->get_name());
+  if (variable_exists) {
     m_log->message(2,
                    "  Reading thickness calving threshold from file '%s'...\n",
                    opt.filename.c_str());


### PR DESCRIPTION
With the changes in the dev branch, it's not possible anymore to provide PISM with a constant threshold for thickness calving.

**To Reproduce**
Running PISM with the command line argument `pismr -i ../input/pism_equi_input.nc ... -calving eigen_calving,thickness_calving -thickness_calving_threshold 75.0 ...` fails with the following error message, instead of taking the provided threshold:
```
* Initializing the 'calving at a threshold thickness' mechanism...
  - Option calving.thickness_calving.file is not set. Trying the input file '../input/pism_equi_input.nc'...
  Reading thickness calving threshold from file '../input/pism_equi_input.nc'...
PISM ERROR: can't find threshold used by the 'calving at threshold' calving method (thickness_calving_threshold) in ../input/pism_equi_input.nc.
```

**Fix**
The condition in [L73](https://github.com/pism/pism/blob/71ef366f2c3cd369a9ef267c241674f41ad61abb/src/frontretreat/calving/CalvingAtThickness.cc#L73) doesn't work as expected, because `opt.filename` defaults to the input file if no `calving.thickness_calving.file` is provided. The proposed fix checks instead, if the variable exists in the file.

**Checklist**
- [ ] update documentation
- [ ] update [`CHANGES.rst`](CHANGES.rst)
- [ ] add regression tests
