### PR TITLE
Fix driving stress scheme at ice margin

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -93,6 +93,8 @@ Changes since v1.2
   till water amount is equal to `hydrology.tillwat_max`. This change should improve
   grounding line movement and make the basal yield stress modification turned on with
   `basal_yield_stress.slippery_grounding_lines` unnecessary.
+- Fix the approximation of the driving stress at floating ice margins. (This fix was
+  contributed by Ronja Reese and Torsten Albrecht.)
 
 Changes from v1.1 to v1.2
 =========================

--- a/doc/sphinx/authorship.rst
+++ b/doc/sphinx/authorship.rst
@@ -5,7 +5,7 @@
 Authorship
 ==========
 
-   *Copyright* |copy| *2004 -- 2020 the PISM authors.*
+   *Copyright* |copy| *2004 -- 2021 the PISM authors.*
 
    *This file is part of PISM. PISM is free software; you can redistribute it and/or
    modify it under the terms of the GNU General Public License as published by the Free
@@ -65,7 +65,7 @@ Research (PIK), and several additional developers listed here.
    * - Ward van Pelt (IMAU)
      - hydrology analysis and design
    * - Ronja Reese (PIK)
-     - sub-shelf mass balance
+     - sub-shelf mass balance, ice shelf numerics, bug fixes
    * - Julien Seguinot (ETH)
      - bug fixes, temperature index model 
    * - Ricarda Winkelmann (PIK)

--- a/doc/sphinx/technical/index.rst
+++ b/doc/sphinx/technical/index.rst
@@ -15,6 +15,8 @@ Technical notes
 
    ssafd-cfbc.rst
 
+   ssafd-flow-line.rst
+
    bombproof.rst
 
    steady-hydrology.rst

--- a/doc/sphinx/technical/ssafd-flow-line.rst
+++ b/doc/sphinx/technical/ssafd-flow-line.rst
@@ -1,0 +1,312 @@
+.. include:: ../global.txt
+
+.. _sec-flow-line-ssa:
+
+Notes about the flow-line SSA
+=============================
+
+Using the same notation as in the rest of the manual, the flow-line case the shallow shelf
+approximation reads
+
+.. math::
+   :label: eq-ssa-flow-line
+
+   \left(4 \nu H u' \right)' = \rho_i\, g\, H\, h'.
+
+Here `u` is the ice velocity, `\nu = \nu(u')` is the ice viscosity, `H` is the ice
+thickness, and `h` is the ice surface elevation.
+
+Let `\alpha = (1 - \rhoi / \rhow)` and note that `h = \alpha\, H` whenever ice is
+floating, so
+
+.. math::
+   :label: eq-ssa-flow-line-2
+
+   \left(4 \bar \nu H u' \right)' = \frac12 \alpha\, \rho_i\, g\, (H^2)'.
+
+We can easily integrate this, getting
+
+.. math::
+   :label: eq-ssa-flow-line-3
+
+   4 \bar \nu H u' = \frac12 \alpha\, \rho_i\, g\, H^2.
+
+.. note::
+
+   This is a non-linear *first-order* ODE for the ice velocity `u`.
+
+.. _sec-ssa-flow-line-invariance:
+
+An observation
+--------------
+
+Consider a boundary-value problem for the velocity `u` of a floating ice shelf on an
+interval `[0, L]`:
+
+.. math::
+   :label: eq-ssa-flowline-bvp
+
+   \left(4 \nu H u' \right)' &= \rho_i\, g\, H\, h',
+
+   u(0) &= u_{0},
+
+   \left. \left( 4\nu H u' \right) \right|_{x=L} &= \tau_{\text{stat}}(L),
+
+   \tau_{\text{stat}}(x) &= \frac12 \rhoi\, g\, \alpha\, H(x)^2.
+
+Now consider a similar BVP on `[0, a]` for some positive `a < L`:
+
+.. math::
+   :label: eq-ssa-flowline-bvp-2
+
+   \left(4 \nu H v' \right)' &= \rho_i\, g\, H\, h',
+
+   v(0) &= u_{0},
+
+   \left. \left( 4\nu(v') H v' \right) \right|_{x=a} &= \tau_{\text{stat}}(a).
+
+Because :eq:`eq-ssa-flowline-bvp` is a first-order ODE, the solutions `u` of
+:eq:`eq-ssa-flowline-bvp` and `v` of :eq:`eq-ssa-flowline-bvp-2` *coincide* on `[0, a]`,
+i.e. `u(x) = v(x)` for all `x \in [0, a]`.
+
+.. note::
+
+   This implies that the velocity `u(x)` of a floating flow-line ice shelf modeled by
+   :eq:`eq-ssa-flowline-bvp` is not sensitive to ice geometry perturbations at locations
+   downstream from `x`.
+
+.. _sec-ssa-flow-line-discretized:
+
+Discrete analog of this property
+--------------------------------
+
+Let `N > 2` be an integer and define the `N`\-point grid `x_{j} = 0 + j\dx`, `\dx =
+L/(N-1)`.
+
+Discretizing :eq:`eq-ssa-flowline-bvp` on this grid results in a non-linear system
+with `N-1` unknowns (call this system `S_{L}`).
+
+Let `a = L - \dx` and write down a system of equations by discretizing
+:eq:`eq-ssa-flowline-bvp-2` on the grid consisting of the first `N-1` of `x_{j}`. This
+system (call it `S_{a}`) has `N-2` unknowns.
+
+The property we would like our discretization to have is this:
+
+   If `u_{1},\dots,u_{N-1}` is the solution of `S_{L}` and `v_{1},\dots,v_{N-2}` solves
+   `S_{a}`, then `u_{k} = v_{k}` for all `k = 1,\dots,N-2`.
+
+Note that the first `N-3` equations in `S_{L}` and `S_{a}` are the same.
+
+.. _sec-ssa-flow-line-discrete:
+
+Discretization
+--------------
+
+Let `[X]_{j}` be an approximation of `X` at a grid location `j`.
+
+The standard approach *within* the domain is to use centered finite differences and linear
+interpolation to approximate staggered-grid values, i.e. averaging values at immediate
+regular grid point neighbors:
+
+.. math::
+   :label: eq-ssa-flow-line-fd-basics
+
+   {}[f]_{i + \frac12} &= \frac12 (f_i + f_{i+1}),
+
+   {}[f']_{i} &= \frac1{\dx}([f]_{i+\frac12} + [f]_{i-\frac12}).
+
+.. _sec-ssafd-flow-line-generic:
+
+Interior
+~~~~~~~~
+
+.. math::
+   :label: eq-ssa-flow-line-interior
+
+   \frac1{\dx} \left( [4\nu(u')H u']_{i+\frac12} - [4\nu(u')H u']_{i-\frac12} \right)
+   = [\rhoi\, g\, \alpha\, H\, H']_{i}.
+
+.. _sec-ssa-flow-line-ice-front:
+
+Ice front
+~~~~~~~~~
+
+Let `n` be the last grid point with non-zero ice thickness, i.e. assume that `H_{k} = 0`
+for `k > n`.
+
+The implementation of the stress boundary condition at the ice front amounts to adding one
+more equation (see :eq:`ssafd-cfbc-vertintbdry`):
+
+.. math::
+   :label: eq-ssa-flow-line-cfbc
+
+   {}[4\nu(u') H u']_{n+\frac12} = [\tau_{\text{stat}}]_{n+\frac12}.
+
+We can then combine :eq:`eq-ssa-flow-line-cfbc` with :eq:`eq-ssa-flow-line-interior` (with
+`i` replaced by `n`) to get the discretization at the ice front:
+
+.. math::
+   :label: eq-ssa-flow-line-cf
+
+   \frac1{\dx}\left( [\tau_{\text{stat}}]_{n+\frac12} - [4\nu(u')H u']_{n-\frac12} \right)
+   &= \rhoi\, g\, \alpha\, [H\, H']_{n},
+
+   - [4\nu(u')H u']_{n-\frac12}
+   &= \dx\rhoi\, g\, \alpha\, [H\, H']_{n} - [\tau_{\text{stat}}]_{n+\frac12}.
+
+.. _sec-ssa-flow-line-fd:
+
+Choosing FD approximations
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. rubric:: Assuming that the ice front is at `n`
+
+If we assume that the ice front is at `n`, the last equation in the system looks like
+:eq:`eq-ssa-flow-line-cf`:
+
+.. math::
+   :label: eq-ssa-flow-line-cf-n
+
+   - [4\nu(u')H u']_{n-\frac12}
+   = \dx\rhoi\, g\, \alpha\, [H\, H']_{n} - [\tau_{\text{stat}}]_{n+\frac12}.
+
+.. rubric:: Assuming that the ice front is at `n+1`
+
+If we assume that the ice front is at `n+1`, the `n`\-th equation looks like a "generic"
+interior equation :eq:`eq-ssa-flow-line-interior` and we have one more equation
+(:eq:`eq-ssa-flow-line-cf-n`) shifted by `1`:
+
+.. math::
+   :label: eq-ssa-flow-line-cf-n-plus-1
+
+   \frac1{\dx} \left( [4\nu(u')H u']_{n+\frac12} - [4\nu(u')H u']_{n-\frac12} \right)
+   &= [\rhoi\, g\, \alpha\, H\, H']_{n}.
+
+   - [4\nu(u')H u']_{(n+1)-\frac12}
+   &= \dx\rhoi\, g\, \alpha\, [H\, H']_{n+1} - [\tau_{\text{stat}}]_{n+1+\frac12}.
+
+Note that the second equation in :eq:`eq-ssa-flow-line-cf-n-plus-1` is the same as
+:eq:`eq-ssa-flow-line-cf-n`, but with the index shifted by `1`. Both correspond to
+locations *at the ice front*.
+
+.. rubric:: The goal
+
+We want to choose FD approximations `[\tau_{\text{stat}}]_{*}` and `[H\, H']_{*}`
+in a way that would make it possible to obtain :eq:`eq-ssa-flow-line-cf-n` by
+transforming equations :eq:`eq-ssa-flow-line-cf-n-plus-1`.
+
+We propose using *constant extrapolation* to approximate `H_{n+\frac12}`
+
+.. math::
+   :label: eq-ssa-flow-line-fd-approx
+
+   {}[H]_{i+\frac12} &=
+   \begin{cases}
+   H_{i}, &i \text{ is at the ice front}\\
+   \frac12(H_{i} + H_{i+1}), &\text{otherwise}.
+   \end{cases}
+
+This gives us the following approximation of derivatives:
+
+.. math::
+
+   {}[H']_{i} &=
+   \begin{cases}
+   \frac1{\dx}(H_{i} - [H]_{i-\frac12}), &i \text{ is at the ice front}\\
+   \frac1{\dx}([H]_{i+\frac12} - [H]_{i-\frac12}), &\text{otherwise}.
+   \end{cases}
+
+After substituting :eq:`eq-ssa-flow-line-fd-basics` this becomes
+
+.. math::
+   :label: eq-ssa-flow-line-fd-approx-derivative
+
+   {}[H']_{i} &=
+   \begin{cases}
+   \frac1{2\dx}(H_{i} - H_{i-1}), &i \text{ is at the ice front}\\
+   \frac1{2\dx}(H_{i+1} - H_{i-1}), &\text{otherwise}.
+   \end{cases}
+
+.. note::
+
+   The ice front case in :eq:`eq-ssa-flow-line-fd-approx-derivative` is the **one half**
+   of the standard one-sided finite-difference approximation of `H'`.
+
+.. rubric:: Checking if :eq:`eq-ssa-flow-line-fd-approx` is the right choice
+
+Consider the first equation in :eq:`eq-ssa-flow-line-cf-n-plus-1` and note that it
+corresponds to the case in which `n` is **not** at the ice front.
+
+.. math::
+
+   \frac1{\dx} \left( [4\nu(u')H u']_{n+\frac12} - [4\nu(u')H u']_{n-\frac12} \right)
+   = [\rhoi\, g\, \alpha\, H\, H']_{n},
+
+Multiplying by `\dx` and moving one of the terms to the right hand side, we get
+
+.. math::
+   :label: eq-ssa-flow-line-cf-n-plus-1-first
+
+   - [4\nu(u')H u']_{n-\frac12}
+   &= \dx[\rhoi\, g\, \alpha\, H\, H']_{n} - [4\nu(u')H u']_{n+\frac12}.
+
+   - [4\nu(u')H u']_{n-\frac12}
+   &= \dx\, \rhoi\, g\, \alpha\, H_{n}\frac{H_{n+1} - H_{n-1}}{2\dx} - [4\nu(u')H u']_{n+\frac12}.
+
+   &= \frac12\, \rhoi\, g\, \alpha\, H_{n}\, (H_{n+1} - H_{n-1}) - [4\nu(u')H u']_{n+\frac12}.
+
+Now consider the second equation in :eq:`eq-ssa-flow-line-cf-n-plus-1`. Note that here
+`n+1` **is** at the ice front.
+
+.. math::
+   :label: eq-ssa-flow-line-cf-n-plus-1-second
+
+   - [4\nu(u')H u']_{(n+1)-\frac12}
+   &= \dx\rhoi\, g\, \alpha\, [H\, H']_{n+1} - [\tau_{\text{stat}}]_{n+1+\frac12}.
+
+   &= \dx\rhoi\, g\, \alpha\, H_{n+1}[H']_{n+1} - \frac12 \rhoi\, g\, \alpha\, [H]_{n+1+\frac12}^{2}.
+
+   &= \dx\rhoi\, g\, \alpha\, H_{n+1}\frac{H_{n+1} - H_{n}}{2\dx} - \frac12 \rhoi\, g\,
+   \alpha\, H_{n+1}^{2}
+
+   &= \frac12\, \rhoi\, g\, \alpha( H_{n+1}(H_{n+1} - H_{n}) - H_{n+1}^{2} )
+
+   &= \frac12\, \rhoi\, g\, \alpha( H_{n+1}^{2} - H_{n+1}H_{n} - H_{n+1}^{2} )
+
+   &= -\frac12\, \rhoi\, g\, \alpha\, H_{n+1}H_{n}.
+
+Put together, :eq:`eq-ssa-flow-line-cf-n-plus-1-first` and
+:eq:`eq-ssa-flow-line-cf-n-plus-1-second` read as follows:
+
+.. math::
+   :label: eq-ssa-flow-line-cf-n-plus-1-rewritten
+
+   - [4\nu(u')H u']_{n-\frac12}
+   &= \frac12\, \rhoi\, g\, \alpha\, H_{n}\, (H_{n+1} - H_{n-1}) - [4\nu(u')H u']_{n+\frac12},
+
+   - [4\nu(u')H u']_{n+\frac12}
+   &= -\frac12\, \rhoi\, g\, \alpha\, H_{n+1}H_{n}.
+
+Substituting the second equation into the first produces
+
+.. math::
+   :label: eq-ssa-flow-line-cf-n-plus-1-final
+
+   - [4\nu(u')H u']_{n-\frac12}
+   &= \frac12\, \rhoi\, g\, \alpha\, H_{n}\, (H_{n+1} - H_{n-1}) - \frac12\, \rhoi\, g\, \alpha\, H_{n+1}H_{n}
+
+   &= \frac12\, \rhoi\, g\, \alpha\, (H_{n}\, (H_{n+1} - H_{n-1}) - H_{n+1}H_{n})
+
+   &= -\frac12\, \rhoi\, g\, \alpha\, H_{n}\, H_{n-1}
+
+Compare :eq:`eq-ssa-flow-line-cf-n-plus-1-final` to
+:eq:`eq-ssa-flow-line-cf-n-plus-1-second`. Note that *they are the same*, except for the
+index shift. In other words, :eq:`eq-ssa-flow-line-cf-n-plus-1-final` is the same as
+:eq:`eq-ssa-flow-line-cf-n`, as desired.
+
+This confirms that finite difference approximations :eq:`eq-ssa-flow-line-fd-approx` and
+:eq:`eq-ssa-flow-line-fd-approx-derivative` result in a discretization with the property
+we seek:
+
+   modeled ice velocity at a given location `x` along a flow-line ice shelf is not
+   sensitive to geometry perturbations downstream from `x`.

--- a/examples/mismip/check_taud_flowline/README.md
+++ b/examples/mismip/check_taud_flowline/README.md
@@ -1,0 +1,15 @@
+Flowline ice shelf model (to test for driving stress scheme)
+=================
+
+
+Run a test to check for the effect of the driving stress scheme for a 50m ice thickness perturbations 
+at the calving front in a flow line ice shelf setup and compare to analytical solution (van Der Veen). 
+
+As in the flow line case no buttressing force exists, the SSA velocity should be unaffected by such perturbations. 
+As surface gradients are low towards the calving front margin, the one-sided difference scheme with calving front 
+boundary conditionproduced solutions comparable to the analytical solution, but it cannot reproduce the expected 
+(absent) perturbation effects. 
+
+     $ bash run_test.sh
+
+provides a plot of anomalies in driving stress and SSA velcoity along the flow line ice shelf.

--- a/examples/mismip/check_taud_flowline/plot_diff.py
+++ b/examples/mismip/check_taud_flowline/plot_diff.py
@@ -1,0 +1,112 @@
+
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib import cm
+import netCDF4 as nc
+
+# ICE FRONT 
+
+#data_path = "/home/albrecht/pism21/pism-dev/examples/mismip/check_taud_flowline2/"
+data_path = ""
+
+experiments = [data_path+'result_1a_A1_800_300_1750e3_601_onesided_',
+               data_path+'result_1a_A1_800_300_1750e3_601_centered_']
+labels = ['one sided', 'centered']
+
+
+# FIXME resolution dependent!!
+
+refdat = data_path+'ICESHELF_1a_A1_800_300_1750e3_601_default.nc'
+ncr    = nc.Dataset(refdat, 'r')
+velref = np.ma.array(ncr.variables["u_ssa_bc"][:])
+ncr.close()
+
+ncr    = nc.Dataset(experiments[0]+'default.nc', 'r')
+mask = np.ma.array(ncr.variables["mask"][0,:])
+x = np.ma.array(ncr.variables["x"][:])
+#thk_ref = np.ma.array(ncr.variables['thk'][0,:])
+#print(np.shape(mask))
+ncr.close()
+
+divide_idx = int(np.floor(mask.shape[1]/2))
+divide_idx = 2
+
+glidxs = np.where(mask[1,divide_idx:]==3)
+glidx = glidxs[0][0]+divide_idx -1 # Last grounded cell
+
+ifidxs = np.where(mask[1,divide_idx:]==4)
+ifidx = ifidxs[0][0]+divide_idx -1
+
+
+#MISMIP
+secpera=3.15569259747e7
+
+
+fig, axes = plt.subplots(4, 2, sharex=False, sharey=False, figsize=(10, 8))
+plt.subplots_adjust( wspace=0.25, hspace=0.1)
+
+for i,exp in enumerate([ 'default.nc', 'p1.nc', 'p2.nc', 'p3.nc']):
+    #print(i, 2*i, 2*i+1,exp)
+    # one figure with changes in ssa vels and one with taud
+    ax2 = axes.flatten()[2*i]
+    ax1 = axes.flatten()[2*i+1]
+    #experiments = glob.glob(os.path.join(data_path, ensemble_id+"_gradienthaseloff/diagnostic_*_"+exp))
+    varname = "u_ssa"
+    
+    ax1.axvline(x=x[glidx]/1000., color='grey', linestyle='--', label=None)
+    ax1.axhline(y=0, color='grey', linestyle='--', label=None)
+    for n,run in enumerate(experiments):
+        refvariable=velref
+
+        ncr    = nc.Dataset(run+exp, 'r')
+        variable = np.ma.array(ncr.variables[varname][0,:])*secpera
+        thk = np.ma.array(ncr.variables['thk'][0,:])
+        ncr.close()
+
+        variable[mask==4] = np.nan
+        ax1.plot(x[divide_idx:]/1000, variable[1,divide_idx:]-refvariable[1,divide_idx:],
+                 linewidth=2*(2-n),
+                 label=labels[n])
+
+    ax1.set_ylim([-2000,500]) # km
+    ax1.set_xlim([0,1760]) # km
+
+    
+    
+    varname = "taud_x"
+    #varname = "taud_mag"
+    ax2.axvline(x=(x[glidx]), color='grey', linestyle='--', label=None)
+    ax2.axhline(y=0, color='grey', linestyle='--', label=None)      
+    for n,run in enumerate(experiments):
+        ncr    = nc.Dataset(run+"default.nc", 'r')
+        refvariable = np.ma.array(ncr.variables[varname][0,:])
+        ncr.close()
+
+        ncr    = nc.Dataset(run+exp, 'r')
+        variable = np.ma.array(ncr.variables[varname][0,:])
+        ncr.close()
+
+
+        variable[mask==4] = np.nan
+        ax2.plot(x[divide_idx:]/1000, variable[1,divide_idx:]-refvariable[1,divide_idx:],
+                    linewidth=2*(2-n),
+                    label=labels[n])
+        ax2.scatter(x[divide_idx:]/1000, variable[1,divide_idx:]-refvariable[1,divide_idx:], label=None)
+    
+    if i==1:    
+      ax2.set_ylabel('Change in driving stress (Pa)')   
+      ax1.set_ylabel('Change in velocity (m/a)')
+    ax2.set_ylim([-1200,600]) # km
+    ax2.set_xlim([1700,1755]) # km      
+    ax2.text(1702,400,exp.split('_')[-1].rstrip('.nc'))
+    if i<3: 
+      ax1.set_xticklabels([])
+      ax2.set_xticklabels([]) 
+ 
+ax = axes.flatten()[0]
+ax.legend(loc='lower right')
+axes.flatten()[6].set_xlabel('Distance from ice divide (km)')
+axes.flatten()[7].set_xlabel('Distance from ice divide (km)')
+
+#plt.savefig('/home/albrecht/www/pism_taudfix/taudfix_margin.png', bbox_inches='tight')
+plt.show()

--- a/examples/mismip/check_taud_flowline/plot_diff.py
+++ b/examples/mismip/check_taud_flowline/plot_diff.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 
 import numpy as np
 import matplotlib.pyplot as plt
@@ -6,107 +7,100 @@ import netCDF4 as nc
 
 # ICE FRONT 
 
-#data_path = "/home/albrecht/pism21/pism-dev/examples/mismip/check_taud_flowline2/"
 data_path = ""
 
 experiments = [data_path+'result_1a_A1_800_300_1750e3_601_onesided_',
                data_path+'result_1a_A1_800_300_1750e3_601_centered_']
 labels = ['one sided', 'centered']
 
-
 # FIXME resolution dependent!!
 
 refdat = data_path+'ICESHELF_1a_A1_800_300_1750e3_601_default.nc'
-ncr    = nc.Dataset(refdat, 'r')
-velref = np.ma.array(ncr.variables["u_ssa_bc"][:])
-ncr.close()
+with nc.Dataset(refdat, 'r') as ncr:
+    velref = np.ma.array(ncr.variables["u_ssa_bc"][1,:])
 
-ncr    = nc.Dataset(experiments[0]+'default.nc', 'r')
-mask = np.ma.array(ncr.variables["mask"][0,:])
-x = np.ma.array(ncr.variables["x"][:])
-#thk_ref = np.ma.array(ncr.variables['thk'][0,:])
-#print(np.shape(mask))
-ncr.close()
+with nc.Dataset(experiments[0]+'default.nc', 'r') as ncr:
+    mask = np.ma.array(ncr.variables["mask"][0,1,:])
+    x = np.ma.array(ncr.variables["x"][:]) / 1000.0 # convert to km
 
-divide_idx = int(np.floor(mask.shape[1]/2))
-divide_idx = 2
+start_idx = 2
 
-glidxs = np.where(mask[1,divide_idx:]==3)
-glidx = glidxs[0][0]+divide_idx -1 # Last grounded cell
-
-ifidxs = np.where(mask[1,divide_idx:]==4)
-ifidx = ifidxs[0][0]+divide_idx -1
-
+# find the index of the last grounded cell gl_idx:
+MASK_FLOATING = 3
+gl_idx = 0
+for i in range(len(x) - 1):
+    if mask[i] < MASK_FLOATING and mask[i + 1] >= MASK_FLOATING:
+        gl_idx = i
+        break
 
 #MISMIP
 secpera=3.15569259747e7
 
+def plot_taud(axis, exp, i):
+    varname = "taud_x"
+    axis.axvline(x=(x[gl_idx]), color='grey', linestyle='--', label=None)
+    axis.axhline(y=0, color='grey', linestyle='--', label=None)
+    for n,run in enumerate(experiments):
+
+        with nc.Dataset(run+"default.nc", 'r') as ncr:
+            refvariable = np.ma.array(ncr.variables[varname][0,1,:])
+
+        with nc.Dataset(run+exp, 'r') as ncr:
+            variable = np.ma.array(ncr.variables[varname][0,1,:])
+
+        variable.mask = mask > MASK_FLOATING
+        axis.plot(x[start_idx:], variable[start_idx:]-refvariable[start_idx:],
+                  linewidth=2*(2-n),
+                  label=labels[n])
+        axis.scatter(x[start_idx:], variable[start_idx:]-refvariable[start_idx:], label=None)
+
+    axis.set_ylim([-1200,600]) # km
+    axis.set_xlim([1700,1755]) # km
+    axis.text(1702,400,exp.split('_')[-1].rstrip('.nc'))
+
+    if i==0:
+      axis.set_title('Change in driving stress (Pa)')
+    if i<3:
+      axis.set_xticklabels([])
+
+def plot_velocity(axis, exp, i):
+    varname = "u_ssa"
+    axis.axvline(x=x[gl_idx], color='grey', linestyle='--', label=None)
+    axis.axhline(y=0, color='grey', linestyle='--', label=None)
+    for n,run in enumerate(experiments):
+        refvariable=velref
+
+        with nc.Dataset(run+exp, 'r') as ncr:
+            variable = np.ma.array(ncr.variables[varname][0,1,:])*secpera
+
+        variable.mask = mask > MASK_FLOATING
+        axis.plot(x[start_idx:], variable[start_idx:] - refvariable[start_idx:],
+                  linewidth=2*(2-n),
+                  label=labels[n])
+
+    axis.set_ylim([-2000,500]) # km
+    axis.set_xlim([0,1760]) # km
+
+    if i==0:
+        axis.set_title('Change in velocity (m/a)')
+    if i<3:
+        axis.set_xticklabels([])
 
 fig, axes = plt.subplots(4, 2, sharex=False, sharey=False, figsize=(10, 8))
 plt.subplots_adjust( wspace=0.25, hspace=0.1)
 
 for i,exp in enumerate([ 'default.nc', 'p1.nc', 'p2.nc', 'p3.nc']):
-    #print(i, 2*i, 2*i+1,exp)
-    # one figure with changes in ssa vels and one with taud
-    ax2 = axes.flatten()[2*i]
-    ax1 = axes.flatten()[2*i+1]
-    #experiments = glob.glob(os.path.join(data_path, ensemble_id+"_gradienthaseloff/diagnostic_*_"+exp))
-    varname = "u_ssa"
-    
-    ax1.axvline(x=x[glidx]/1000., color='grey', linestyle='--', label=None)
-    ax1.axhline(y=0, color='grey', linestyle='--', label=None)
-    for n,run in enumerate(experiments):
-        refvariable=velref
+    # plot changes is taud
+    axis = axes.flatten()[2*i]
+    plot_taud(axis, exp, i)
 
-        ncr    = nc.Dataset(run+exp, 'r')
-        variable = np.ma.array(ncr.variables[varname][0,:])*secpera
-        thk = np.ma.array(ncr.variables['thk'][0,:])
-        ncr.close()
+    # plot changes in ice velocity
+    axis = axes.flatten()[2*i+1]
+    plot_velocity(axis, exp, i)
 
-        variable[mask==4] = np.nan
-        ax1.plot(x[divide_idx:]/1000, variable[1,divide_idx:]-refvariable[1,divide_idx:],
-                 linewidth=2*(2-n),
-                 label=labels[n])
-
-    ax1.set_ylim([-2000,500]) # km
-    ax1.set_xlim([0,1760]) # km
-
-    
-    
-    varname = "taud_x"
-    #varname = "taud_mag"
-    ax2.axvline(x=(x[glidx]), color='grey', linestyle='--', label=None)
-    ax2.axhline(y=0, color='grey', linestyle='--', label=None)      
-    for n,run in enumerate(experiments):
-        ncr    = nc.Dataset(run+"default.nc", 'r')
-        refvariable = np.ma.array(ncr.variables[varname][0,:])
-        ncr.close()
-
-        ncr    = nc.Dataset(run+exp, 'r')
-        variable = np.ma.array(ncr.variables[varname][0,:])
-        ncr.close()
-
-
-        variable[mask==4] = np.nan
-        ax2.plot(x[divide_idx:]/1000, variable[1,divide_idx:]-refvariable[1,divide_idx:],
-                    linewidth=2*(2-n),
-                    label=labels[n])
-        ax2.scatter(x[divide_idx:]/1000, variable[1,divide_idx:]-refvariable[1,divide_idx:], label=None)
-    
-    if i==1:    
-      ax2.set_ylabel('Change in driving stress (Pa)')   
-      ax1.set_ylabel('Change in velocity (m/a)')
-    ax2.set_ylim([-1200,600]) # km
-    ax2.set_xlim([1700,1755]) # km      
-    ax2.text(1702,400,exp.split('_')[-1].rstrip('.nc'))
-    if i<3: 
-      ax1.set_xticklabels([])
-      ax2.set_xticklabels([]) 
- 
 ax = axes.flatten()[0]
 ax.legend(loc='lower right')
 axes.flatten()[6].set_xlabel('Distance from ice divide (km)')
 axes.flatten()[7].set_xlabel('Distance from ice divide (km)')
 
-#plt.savefig('/home/albrecht/www/pism_taudfix/taudfix_margin.png', bbox_inches='tight')
 plt.show()

--- a/examples/mismip/check_taud_flowline/prepare_iceshelf.py
+++ b/examples/mismip/check_taud_flowline/prepare_iceshelf.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python
+
+try:
+    from netCDF4 import Dataset as NC
+except:
+    print("netCDF4 is not installed!")
+    sys.exit(1)
+
+import MISMIP
+
+import numpy as np
+
+
+def bcmask(x):
+
+    bcm = np.zeros_like(x)
+
+    bcm[x < 100e3] = 1.0
+    #bcm[x < 105e3] = 1.0
+
+    return np.tile(bcm, (3, 1))
+
+
+def bed_topography(x):
+
+    bed = np.zeros_like(x)
+
+    #linear
+    bed = -(x-100e3)*(1000.0)/2000e3 -500.0
+    #constant
+    #bed[x >= 100e3] = -500.0
+    #bed[x < 100e3] = -500.0
+
+
+    return np.tile(bed, (3, 1))
+
+
+
+def surface_mass_balance(x):
+    """Computes the surface mass balance."""
+    return np.tile(np.zeros_like(x) + MISMIP.a()*0.0, (3, 1)) * MISMIP.rho_i()
+
+
+def ice_surface_temp(x):
+    """Computes the ice surface temperature (irrelevant)."""
+    return np.tile(np.zeros_like(x) + 273.15, (3, 1))
+
+
+def x(N=None):
+
+    return np.linspace(0, MISMIP.L(), N)
+
+
+def y(x):
+    """Computes y coordinates giving the 1:1 aspect ratio.
+    Takes cross-flow grid periodicity into account."""
+    dx = x[1] - x[0]
+    dy = dx
+    return np.array([-dy, 0, dy])
+
+
+def thickness(x, step, Q0, H0, calving_front=1750e3, perturbation='default'):
+
+    # we expect x to have an odd number of grid points so that one of them is
+    # at 0
+    if x.size % 2 != 1:
+        raise ValueError("x has to have an odd number of points, got %d", x.size)
+
+    dx=x[1]-x[0]
+    thk = np.zeros_like(x)
+    A0 = MISMIP.A('1a', step)
+    print A0,A0**(-1.0/3.0)
+    B0 = A0**(-1.0/MISMIP.n())
+    #C = (900.0*9.8/(4.0*B0)*(1.0-900.0/1000.0))**3.0
+    C = (MISMIP.rho_i()*MISMIP.g()/(4.0*B0)*(1.0-MISMIP.rho_i()/MISMIP.rho_w()))**MISMIP.n()
+
+    thk = (4.0*C*(x-100e3)/Q0 + H0**(-4.0))**(-0.25)
+    #thk = (x-100e3)*(-1e-4) + 800.0
+    thk[x < 100e3] = 800.0
+    thk[0]=0.0
+    if perturbation=='p1':
+      #perturbation i
+      thk[ x > calving_front-1*dx ] -= 50.0
+    elif perturbation=='p2':
+      #perutbation i-1
+      thk[ x > calving_front-2*dx ] -= 50.0 
+      thk[ x > calving_front-1*dx ] += 50.0
+    elif perturbation=='p3':
+      #perutbation i-2
+      thk[ x > calving_front-3*dx ] -= 50.0
+      thk[ x > calving_front-2*dx ] += 50.0 
+    #perutbation gli+1
+    #thk[ x > 100e3 + 0.5*dx ] -= 200.0
+    #thk[ x > 100e3+1.5*dx ] += 200.0
+    #perutbation gli+2
+    #thk[ x > 100e3 + 1.5*dx ] -= 200.0
+    #thk[ x > 100e3+2.5*dx ] += 200.0
+
+    thk[x > calving_front] = 0.0
+
+    return np.tile(thk, (3, 1))
+
+def ocean_kill(H):
+    """Defines a ice front boundary, at which ice calves off."""
+    ok=np.ones_like(H)
+    ok[H==0]=0
+    return ok
+
+
+def config(step):
+        '''Generates a config file containing flags and parameters
+        for a particular experiment and step.
+
+        This takes care of flags and parameters that *cannot* be set using
+        command-line options. (We try to use command-line options whenever we can.)
+        '''
+        model = 1
+        experiment = '1a'
+        filename = "MISMIP_conf_%s_A%s.nc" % (experiment, step)
+
+        nc = NC(filename, 'w', format="NETCDF3_CLASSIC")
+
+        var = nc.createVariable("pism_overrides", 'i')
+
+        attrs = {"stress_balance.ssa.fd.flow_line_mode": "true",
+                 "geometry.update.use_basal_melt_rate": "no",
+                 "stress_balance.ssa.compute_surface_gradient_inward": "no",
+                 "flow_law.isothermal_Glen.ice_softness": MISMIP.A(experiment, step),
+                 "constants.ice.density": MISMIP.rho_i(),
+                 "constants.sea_water.density": MISMIP.rho_w(),
+                 "bootstrapping.defaults.geothermal_flux": 0.0,
+                 "stress_balance.ssa.Glen_exponent": MISMIP.n(),
+                 "constants.standard_gravity": MISMIP.g(),
+                 "ocean.sub_shelf_heat_flux_into_ice": 0.0,
+                 }
+
+        if model != 1:
+            attrs["stress_balance.sia.bed_smoother.range"] = 0.0
+
+        for name, value in attrs.items():
+            var.setncattr(name, value)
+
+        nc.close()
+
+        return filename
+
+
+
+def pism_bootstrap_file(filename, step,
+                        v0, H0, calving_front=1750e3, N=None,p="default"):
+    import PISMNC
+
+    xx = x(N)
+    yy = y(xx)
+
+    print "dx",xx[1]-xx[0]
+
+    v0 = v0/MISMIP.secpera()
+    #H0 = 800.0
+    Q0 = H0*v0
+
+    topg = bed_topography(xx)
+    thk = thickness(xx, step, Q0, H0, calving_front, p)
+    smb = surface_mass_balance(xx)
+    temp = ice_surface_temp(xx)
+    vel = Q0/thk*MISMIP.secpera()
+    vel[thk==0.0]=0.0
+    #vel = np.nan_to_num(Q0/thk)*MISMIP.secpera()
+    bcm = bcmask(xx)
+    vel0 = np.zeros_like(vel)
+    okill = ocean_kill(thk)
+
+
+
+
+
+    nc = PISMNC.PISMDataset(filename, 'w', format="NETCDF3_CLASSIC")
+
+    nc.create_dimensions(xx, yy)
+
+    nc.define_2d_field('topg',
+                       attrs={'units': 'm',
+                              'long_name': 'bedrock surface elevation',
+                              'standard_name': 'bedrock_altitude'})
+    nc.write('topg', topg)
+
+    nc.define_2d_field('thk',
+                       attrs={'units': 'm',
+                              'long_name': 'ice thickness',
+                              'standard_name': 'land_ice_thickness'})
+    nc.write('thk', thk)
+
+    nc.define_2d_field('climatic_mass_balance',
+                       attrs={'units': 'kg m-2 / s',
+                              'long_name': 'ice-equivalent surface mass balance (accumulation/ablation) rate',
+                              'standard_name': 'land_ice_surface_specific_mass_balance_flux'})
+    nc.write('climatic_mass_balance', smb)
+
+    nc.define_2d_field('ice_surface_temp',
+                       attrs={'units': 'Kelvin',
+                              'long_name': 'annual average ice surface temperature, below firn processes'})
+    nc.write('ice_surface_temp', temp)
+
+    nc.define_2d_field('land_ice_area_fraction_retreat',
+                       attrs={'units': '',
+                              'long_name': 'mask where -ocean_kill cuts off ice'})
+    nc.write('land_ice_area_fraction_retreat', okill)
+
+    nc.define_2d_field('u_ssa_bc',
+                       attrs={'units': 'm/yr'
+                              })
+    nc.write('u_ssa_bc', vel)
+
+    nc.define_2d_field('v_ssa_bc',
+                       attrs={'units': 'm/yr'
+                              })
+    nc.write('v_ssa_bc', vel0)
+
+
+    nc.define_2d_field('bc_mask',
+                       attrs={
+                              })
+    nc.write('bc_mask', bcm)
+
+
+    nc.close()
+
+
+if __name__ == "__main__":
+
+    from optparse import OptionParser
+
+    parser = OptionParser()
+
+    parser.usage = "%prog [options]"
+    parser.description = "Creates a MISMIP boostrapping file for use with PISM."
+    parser.add_option("-o", dest="output_filename",
+                      help="output file")
+    parser.add_option("-p", "--perturbation", dest="perturbation", type="string",
+                      help="Perturbation at calving front (50m less at last cell (p1) or penultimate cell (p2))",
+                      default="default")
+    parser.add_option("-H", "--thickness", dest="H0", type="float", default=800.0,
+                      help="input thickness")
+
+    parser.add_option("-v", "--velocity", dest="v0", type="float", default=300.0,
+                      help="input velocity")
+
+    parser.add_option("-s", "--step", dest="step", type="int", default=1,
+                      help="MISMIP step")
+    parser.add_option("-N", dest="N", type="int", default=3601,
+                      help="Custom grid size; use with --mode=3")
+    parser.add_option("-c", dest="calving_front", type="float", default=1600e3,
+                      help="Calving front location, in meters (e.g. 1600e3)")
+
+    (opts, args) = parser.parse_args()
+
+
+    if not opts.output_filename:
+        output_filename = "ICESHELF_%d.nc" % opts.step
+    else:
+        output_filename = opts.output_filename
+
+    print("Creating ICESHELF setup for step %s in %s..." % (
+        opts.step, output_filename))
+
+    config(opts.step)
+
+    pism_bootstrap_file(output_filename,
+                        opts.step,
+                        opts.v0,
+                        opts.H0,
+                        calving_front=opts.calving_front,
+                        N=opts.N,
+                        p=opts.perturbation)
+
+    print("done.")

--- a/examples/mismip/check_taud_flowline/prepare_iceshelf.py
+++ b/examples/mismip/check_taud_flowline/prepare_iceshelf.py
@@ -69,7 +69,7 @@ def thickness(x, step, Q0, H0, calving_front=1750e3, perturbation='default'):
     dx=x[1]-x[0]
     thk = np.zeros_like(x)
     A0 = MISMIP.A('1a', step)
-    print A0,A0**(-1.0/3.0)
+    print(A0,A0**(-1.0/3.0))
     B0 = A0**(-1.0/MISMIP.n())
     #C = (900.0*9.8/(4.0*B0)*(1.0-900.0/1000.0))**3.0
     C = (MISMIP.rho_i()*MISMIP.g()/(4.0*B0)*(1.0-MISMIP.rho_i()/MISMIP.rho_w()))**MISMIP.n()
@@ -153,7 +153,7 @@ def pism_bootstrap_file(filename, step,
     xx = x(N)
     yy = y(xx)
 
-    print "dx",xx[1]-xx[0]
+    print("dx",xx[1]-xx[0])
 
     v0 = v0/MISMIP.secpera()
     #H0 = 800.0

--- a/examples/mismip/check_taud_flowline/run_test.sh
+++ b/examples/mismip/check_taud_flowline/run_test.sh
@@ -1,0 +1,44 @@
+
+H0=800
+v0=300
+ca=1750e3
+N0=601
+#N0=1801
+#N0=3001
+
+ln -s ../mismip2d/MISMIP.py
+ln -s ../../preprocessing/PISMNC.py
+#python get_conf.py -e 1a --mode=1
+
+for scheme in "onesided" "centered" 
+do
+for per in "default" "p1" "p2" "p3"
+do
+rf=result_1a_A1_${H0}_${v0}_${ca}_${N0}_${scheme}_${per}.nc
+of=ICESHELF_1a_A1_${H0}_${v0}_${ca}_${N0}_${per}.nc
+python prepare_iceshelf.py -c $ca -v $v0 -H $H0 -o $of -N $N0 -p $per 2>/dev/null
+
+addopt=""
+if [[ "$scheme" == "centered" ]]; then
+  addopt="-taudfix"
+fi
+
+/home/albrecht/pism21/pism-dev/bin/pismr -i $of -bootstrap -Mx $N0 -My 3 -Mz 15 -Lz 6000 \
+-energy none -no_mass -shelf_base_melt_rate 0.0 \
+-stress_balance ssa -ssa_dirichlet_bc -ssa_flow_law isothermal_glen \
+-ssa_method fd -cfbc -part_grid -ssafd_ksp_rtol 1e-7 \
+-yield_stress constant -tauc 7.624000e+06 -pseudo_plastic -pseudo_plastic_q 3.333333e-01 -pseudo_plastic_uthreshold 3.155693e+07 \
+-front_retreat_file $of \
+-config_override MISMIP_conf_1a_A1.nc \
+-ys 0 -ye 0.0001 -options_left \
+-o $rf -o_order zyx -o_size big \
+$addopt >> pism.out
+
+echo $rf $of $addopt
+#python plot_iceshelf.py $rf $of
+done
+done
+
+python plot_diff.py
+
+

--- a/examples/mismip/check_taud_flowline/run_test.sh
+++ b/examples/mismip/check_taud_flowline/run_test.sh
@@ -16,29 +16,27 @@ for per in "default" "p1" "p2" "p3"
 do
 rf=result_1a_A1_${H0}_${v0}_${ca}_${N0}_${scheme}_${per}.nc
 of=ICESHELF_1a_A1_${H0}_${v0}_${ca}_${N0}_${per}.nc
-python prepare_iceshelf.py -c $ca -v $v0 -H $H0 -o $of -N $N0 -p $per 2>/dev/null
+python3 prepare_iceshelf.py -c $ca -v $v0 -H $H0 -o $of -N $N0 -p $per
 
 addopt=""
 if [[ "$scheme" == "centered" ]]; then
   addopt="-taudfix"
 fi
 
-/home/albrecht/pism21/pism-dev/bin/pismr -i $of -bootstrap -Mx $N0 -My 3 -Mz 15 -Lz 6000 \
+pismr -i $of -bootstrap -Mx $N0 -My 3 -Mz 15 -Lz 6000 \
 -energy none -no_mass -shelf_base_melt_rate 0.0 \
 -stress_balance ssa -ssa_dirichlet_bc -ssa_flow_law isothermal_glen \
 -ssa_method fd -cfbc -part_grid -ssafd_ksp_rtol 1e-7 \
 -yield_stress constant -tauc 7.624000e+06 -pseudo_plastic -pseudo_plastic_q 3.333333e-01 -pseudo_plastic_uthreshold 3.155693e+07 \
 -front_retreat_file $of \
 -config_override MISMIP_conf_1a_A1.nc \
--ys 0 -ye 0.0001 -options_left \
+-ys 0 -ye 0.0001 \
 -o $rf -o_order zyx -o_size big \
-$addopt >> pism.out
+$addopt > pism-${scheme}-${per}.log
 
 echo $rf $of $addopt
-#python plot_iceshelf.py $rf $of
+
 done
 done
 
-python plot_diff.py
-
-
+python3 plot_diff.py

--- a/examples/mismip/check_taud_flowline/run_test.sh
+++ b/examples/mismip/check_taud_flowline/run_test.sh
@@ -1,42 +1,41 @@
+#!/bin/bash
 
 H0=800
 v0=300
 ca=1750e3
 N0=601
-#N0=1801
-#N0=3001
 
 ln -s ../mismip2d/MISMIP.py
 ln -s ../../preprocessing/PISMNC.py
-#python get_conf.py -e 1a --mode=1
 
-for scheme in "onesided" "centered" 
-do
 for per in "default" "p1" "p2" "p3"
 do
-rf=result_1a_A1_${H0}_${v0}_${ca}_${N0}_${scheme}_${per}.nc
-of=ICESHELF_1a_A1_${H0}_${v0}_${ca}_${N0}_${per}.nc
-python3 prepare_iceshelf.py -c $ca -v $v0 -H $H0 -o $of -N $N0 -p $per
+  rf=result_1a_A1_${H0}_${v0}_${ca}_${N0}_${per}.nc
+  of=ICESHELF_1a_A1_${H0}_${v0}_${ca}_${N0}_${per}.nc
+  python3 prepare_iceshelf.py -c $ca -v $v0 -H $H0 -o $of -N $N0 -p $per
 
-addopt=""
-if [[ "$scheme" == "centered" ]]; then
-  addopt="-taudfix"
-fi
+  pismr \
+    -Lz 6000 \
+    -Mx $N0 \
+    -My 3 \
+    -Mz 3 \
+    -bootstrap \
+    -cfbc \
+    -energy none \
+    -i $of \
+    -no_mass \
+    -o $rf -o_order zyx -o_size big \
+    -ssa_dirichlet_bc \
+    -ssa_flow_law isothermal_glen \
+    -ssa_method fd \
+    -stress_balance ssa \
+    -stress_balance.ssa.fd.flow_line_mode \
+    -y 1s \
+    > pism-${per}.log
+    # -ssafd_ksp_rtol 1e-7 \
 
-pismr -i $of -bootstrap -Mx $N0 -My 3 -Mz 15 -Lz 6000 \
--energy none -no_mass -shelf_base_melt_rate 0.0 \
--stress_balance ssa -ssa_dirichlet_bc -ssa_flow_law isothermal_glen \
--ssa_method fd -cfbc -part_grid -ssafd_ksp_rtol 1e-7 \
--yield_stress constant -tauc 7.624000e+06 -pseudo_plastic -pseudo_plastic_q 3.333333e-01 -pseudo_plastic_uthreshold 3.155693e+07 \
--front_retreat_file $of \
--config_override MISMIP_conf_1a_A1.nc \
--ys 0 -ye 0.0001 \
--o $rf -o_order zyx -o_size big \
-$addopt > pism-${scheme}-${per}.log
+  echo $rf $of $addopt
 
-echo $rf $of $addopt
-
-done
 done
 
 python3 plot_diff.py

--- a/examples/mismip/check_taud_flowline/run_test.sh
+++ b/examples/mismip/check_taud_flowline/run_test.sh
@@ -25,6 +25,7 @@ do
     -i $of \
     -no_mass \
     -o $rf -o_order zyx -o_size big \
+    -output.sizes.big taud \
     -ssa_dirichlet_bc \
     -ssa_flow_law isothermal_glen \
     -ssa_method fd \

--- a/src/pism_config.cdl
+++ b/src/pism_config.cdl
@@ -1850,7 +1850,7 @@ netcdf pism_config {
     pism_config:output.size_option = "o_size";
     pism_config:output.size_type = "keyword";
 
-    pism_config:output.sizes.big = "cts,liqfrac,temp,temp_pa,uvel,vvel,wvel,wvel_rel";
+    pism_config:output.sizes.big = "cts,liqfrac,temp,temp_pa,uvel,vvel,wvel,wvel_rel,taud";
     pism_config:output.sizes.big_doc = "Comma-separated list of variables to write to the output (in addition to ``model_state`` variables and variables listed in :config:`output.sizes.medium` and :config:`output.sizes.big_2d`) if ``big`` output size is selected. Does not include fields written by sub-models.";
     pism_config:output.sizes.big_type = "string";
 
@@ -1984,6 +1984,11 @@ netcdf pism_config {
     pism_config:stress_balance.calving_front_stress_bc_doc = "Apply CFBC condition as in :cite:`Albrechtetal2011`, :cite:`Winkelmannetal2011`.  May only apply to some stress balances; e.g. SSAFD as of May 2011.  If not set then a strength-extension is used, as in :cite:`BBssasliding`.";
     pism_config:stress_balance.calving_front_stress_bc_option = "cfbc";
     pism_config:stress_balance.calving_front_stress_bc_type = "flag";
+
+    pism_config:stress_balance.fix_taud_at_margin = "no";
+    pism_config:stress_balance.fix_taud_at_margin_doc = "Fix one-sided scheme for driving stress calculation at calving front";
+    pism_config:stress_balance.fix_taud_at_margin_option = "taudfix";
+    pism_config:stress_balance.fix_taud_at_margin_type = "flag";
 
     pism_config:stress_balance.ice_free_thickness_standard = 10.0;
     pism_config:stress_balance.ice_free_thickness_standard_doc = "If ice is thinner than this standard then a cell is considered ice-free for purposes of computing ice velocity distribution.";

--- a/src/pism_config.cdl
+++ b/src/pism_config.cdl
@@ -1850,7 +1850,7 @@ netcdf pism_config {
     pism_config:output.size_option = "o_size";
     pism_config:output.size_type = "keyword";
 
-    pism_config:output.sizes.big = "cts,liqfrac,temp,temp_pa,uvel,vvel,wvel,wvel_rel,taud";
+    pism_config:output.sizes.big = "cts,liqfrac,temp,temp_pa,uvel,vvel,wvel,wvel_rel";
     pism_config:output.sizes.big_doc = "Comma-separated list of variables to write to the output (in addition to ``model_state`` variables and variables listed in :config:`output.sizes.medium` and :config:`output.sizes.big_2d`) if ``big`` output size is selected. Does not include fields written by sub-models.";
     pism_config:output.sizes.big_type = "string";
 

--- a/src/pism_config.cdl
+++ b/src/pism_config.cdl
@@ -1985,11 +1985,6 @@ netcdf pism_config {
     pism_config:stress_balance.calving_front_stress_bc_option = "cfbc";
     pism_config:stress_balance.calving_front_stress_bc_type = "flag";
 
-    pism_config:stress_balance.fix_taud_at_margin = "no";
-    pism_config:stress_balance.fix_taud_at_margin_doc = "Fix one-sided scheme for driving stress calculation at calving front";
-    pism_config:stress_balance.fix_taud_at_margin_option = "taudfix";
-    pism_config:stress_balance.fix_taud_at_margin_type = "flag";
-
     pism_config:stress_balance.ice_free_thickness_standard = 10.0;
     pism_config:stress_balance.ice_free_thickness_standard_doc = "If ice is thinner than this standard then a cell is considered ice-free for purposes of computing ice velocity distribution.";
     pism_config:stress_balance.ice_free_thickness_standard_type = "number";

--- a/test/regression/ssa/ssa_test_cfbc_fd.sh
+++ b/test/regression/ssa/ssa_test_cfbc_fd.sh
@@ -33,11 +33,11 @@ set +e
 diff ${output} -  <<END-OF-OUTPUT
 NUMERICAL ERRORS in velocity relative to exact solution:
 velocity  :  maxvector   prcntavvec      maxu      maxv       avu       avv
-                1.0998      0.06498    1.0998    0.0000    0.6331    0.0000
+                0.1050      0.00506    0.1050    0.0000    0.0493    0.0000
 NUM ERRORS DONE
 NUMERICAL ERRORS in velocity relative to exact solution:
 velocity  :  maxvector   prcntavvec      maxu      maxv       avu       avv
-                0.5112      0.02765    0.5112    0.0000    0.2697    0.0000
+                0.0778      0.00633    0.0778    0.0000    0.0618    0.0000
 NUM ERRORS DONE
 END-OF-OUTPUT
 


### PR DESCRIPTION
This is a fix that has been manily developed by @ronjareese and @talbrecht in 2019. As in the flow line case no buttressing force exists, the SSA velocity should be unaffected by such perturbations. As gradients are low towards the calving front margin, the one-sided difference scheme produced solutions comparable to the analytical solution (van der Veen), but not the correct perturbation effects. Perturbations have been tested in the last and penultimate grid cell towards the calving front by reducing ice thickness by 50m. With the centered difference instead of one-sided difference the SSA velocity over the computational domain is almost unaffected by changes at the calving front.

**Checklist**

- [x] update documentation
- [x] update [`CHANGES.rst`](CHANGES.rst)
- [ ] add regression tests
