### PR TITLE
Pik/fix pico neighbors

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,7 +47,9 @@ Changes since v1.2
 - Implement experiments A,B,C,D,E from the ISMIP-HOM intercomparison.
 - Adjust PICO ocean input average across covered basins, in which the ice shelf has
   in fact a connection to the ocean. Large ice shelves, that cover across two basins,
-  that do not share an ocean boundary, are split into two separate ice shelf instances
+  that do not share an ocean boundary, are split into two separate ice shelf instances.
+- Define PICO basin neighbors at bootstrap and store this list in the basins
+  variable metadata.
 - Implement scaling of calving rates using a time-dependent factor. Set
   `calving.rate_scaling.file` to the name of the file containing `frac_calving_rate`
   (units: "1").

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,7 +49,11 @@ Changes since v1.2
   in fact a connection to the ocean. Large ice shelves, that cover across two basins,
   that do not share an ocean boundary, are split into two separate ice shelf instances.
 - Define PICO basin neighbors at bootstrap and store this list in the basins
-  variable metadata.
+  variable metadata. Option `-update_pico_neighbors` will update basin adjacency at each
+  time step according to current ocean boundary
+- Add PICO option `pico_surf_pressure_melt` to limit the ocean input temperature to surface
+  melting point, assuming that ocean water will not cool below this value when transported to
+  the grounding line.  
 - Implement scaling of calving rates using a time-dependent factor. Set
   `calving.rate_scaling.file` to the name of the file containing `frac_calving_rate`
   (units: "1").

--- a/doc/sphinx/climate_forcing/ocean.rst
+++ b/doc/sphinx/climate_forcing/ocean.rst
@@ -172,14 +172,17 @@ transported by the overturning circulation into the ice shelf cavity and towards
 grounding line. The basin mask defines regions of similar, large-scale ocean conditions;
 each region is marked with a distinct positive integer. In PICO, ocean input temperature
 and salinity are averaged on the continental shelf within each basins. For each ice shelf,
-the input values of the overturning circulation are calculated as an area-weighted average
-over all basins that intersect the ice shelf. Only those basins are considered in the average, 
-in which the ice shelf has in fact a connection to the ocean. Large ice shelves, that cover 
-across two basins, that do not share an ocean boundary, are considered as two separate ice 
-shelves with individual ocean inputs. If ocean input parameters cannot be
-identified, standard values are used (**Warning:** this could strongly influence melt
-rates computed by PICO). In regions where the PICO geometry cannot be identified,
-:cite:`BeckmannGoosse2003` is applied.
+the input values for the overturning circulation are calculated as an area-weighted average
+over all neighboring basins that intersect the ice shelf. Large ice shelves, that cover
+across two basins, that do not share an ocean boundary (and hence are not neighbors), are
+considered as two separate ice shelves with individual ocean inputs. Only those neighboring
+basins are considered in the average, in which the ice shelf has in fact a connection to
+the ocean. If ice shelves become isolated within a basin without an open ocean connection,
+ocean inputs of the neighoring basin will be considered. The indices of the basin neighbors
+are defined at bootstrap and are stored as metadata in the basin state variable and will be
+read at restart. If ocean input parameters cannot be identified, standard values are used
+(**Warning:** this could strongly influence melt rates computed by PICO). In regions where
+the PICO geometry cannot be identified, :cite:`BeckmannGoosse2003` is applied.
 
 .. rubric:: Parameters
 

--- a/doc/sphinx/climate_forcing/ocean.rst
+++ b/doc/sphinx/climate_forcing/ocean.rst
@@ -142,13 +142,13 @@ overturning circulation in ice shelf cavities that drives the exchange with open
 water masses. It is based on the ocean box model of :cite:`OlbersHellmer2010` and includes
 a geometric approach which makes it applicable to ice shelves that evolve in two
 horizontal dimensions. For each ice shelf, PICO solves the box model equations describing
-the transport between coarse ocean boxes. It applies a boundary layer melt formulation
-:cite:`HellmerOlbers1989`, :cite:`HollandJenkins1999`. The overturning circulation is
-driven by the ice-pump :cite:`LewisPerkin1986`: melting at the ice-shelf base reduces the
-density of ambient water masses. Buoyant water rising along the shelf base draws in ocean
-water at depth, which flows across the continental shelf towards the deep grounding lines.
-The model captures this circulation by defining consecutive boxes following the flow
-within the ice shelf cavity, with the first box adjacent to the grounding line. The
+the transport between consecutive coarse ocean boxes at the ice shelf's subsurface. It
+applies a boundary layer melt formulation :cite:`HellmerOlbers1989`, :cite:`HollandJenkins1999`.
+The overturning circulation is driven by the ice-pump :cite:`LewisPerkin1986`: melting at the
+ice-shelf base reduces the density of ambient water masses. Buoyant water rising along the shelf
+base draws in ocean water at depth, which flows across the continental shelf towards the deep
+grounding lines. The model captures this circulation by defining consecutive boxes following the
+flow within the ice shelf cavity, with the first box adjacent to the grounding line. The
 extents of the ocean boxes are computed adjusting to the evolving grounding lines and
 calving fronts. Open ocean properties in front of the shelf as well as the geometry of the
 shelf determine basal melt rate and basal temperature at each grid point.
@@ -169,18 +169,30 @@ Forcing ocean temperature and salinity are taken from the water masses that occu
 floor in front of the ice shelves, which extends down to a specified continental shelf
 depth (see :config:`ocean.pico.continental_shelf_depth`). These water masses are
 transported by the overturning circulation into the ice shelf cavity and towards the
-grounding line. The basin mask defines regions of similar, large-scale ocean conditions;
+grounding line. PICO applies the pressure melting temperature at grounding line depth as
+the lower limit on ocean input temperature. Assuming that no phyical processes are at play
+between the cooling of surface water and the sinking and transport to the grounding line,
+alternatively the surface melting point can be chosen as lower bound in PICO by
+setting :config:`ocean.pico.limit_pressure_melting_at_surface`. Within the PICO boxes,
+however, melting can lower the water temperature even up to the pressure melting point.
+
+The basin mask defines regions of similar, large-scale ocean conditions;
 each region is marked with a distinct positive integer. In PICO, ocean input temperature
 and salinity are averaged on the continental shelf within each basins. For each ice shelf,
 the input values for the overturning circulation are calculated as an area-weighted average
-over all neighboring basins that intersect the ice shelf. Large ice shelves, that cover
-across two basins, that do not share an ocean boundary (and hence are not neighbors), are
-considered as two separate ice shelves with individual ocean inputs. Only those neighboring
-basins are considered in the average, in which the ice shelf has in fact a connection to
-the ocean. If ice shelves become isolated within a basin without an open ocean connection,
-ocean inputs of the neighoring basin will be considered. The indices of the basin neighbors
-are defined at bootstrap and are stored as metadata in the basin state variable and will be
-read at restart. If ocean input parameters cannot be identified, standard values are used
+over all neighboring basins that intersect the ice shelf. PICO infers for the basin adjacency
+at bootsrap for a given initial coastline and stores this indices in the :var:`basins` state
+variable metadata and will be read at restart. As changing ice and bed geomentry can alter basin
+adjacency, setting :config:`ocean.pico.update_basin_neighbors` will update basin neighbors at
+each PISM time step. However, this can lead to flipping neighbor and hence alternating
+melting conditions.
+
+Large ice shelves, that cover across two basins, that do not share an ocean boundary (and
+hence are not neighbors), are considered as two separate ice shelves with individual ocean
+inputs. Only those neighboring basins are considered in the average, in which the ice shelf
+has in fact a connection to the ocean. If ice shelves become isolated within a basin without
+an open ocean connection, ocean inputs of the neighoring basin will be considered. If ocean
+input parameters cannot be identified, standard values are used
 (**Warning:** this could strongly influence melt rates computed by PICO). In regions where
 the PICO geometry cannot be identified, :cite:`BeckmannGoosse2003` is applied.
 

--- a/src/coupler/ocean/Pico.cc
+++ b/src/coupler/ocean/Pico.cc
@@ -471,6 +471,7 @@ void Pico::set_ocean_input_fields(const PicoPhysics &physics,
                                   const std::vector<double> &basin_salinity,
                                   IceModelVec2S &Toc_box0,
                                   IceModelVec2S &Soc_box0) const {
+
   
   IceModelVec::AccessList list{ &ice_thickness, &basin_mask, &Soc_box0, &Toc_box0, &mask, &shelf_mask, &isolated_basin_mask };
 
@@ -559,6 +560,8 @@ void Pico::set_ocean_input_fields(const PicoPhysics &physics,
     }
   }
 
+  bool set_surface_pressure_limit = m_config->get_flag("ocean.pico.limit_pressure_melting_at_surface");
+
   // now set potential temperature and salinity box 0:
 
   int low_temperature_counter = 0;
@@ -585,7 +588,12 @@ void Pico::set_ocean_input_fields(const PicoPhysics &physics,
 
       }
 
-      double theta_pm = physics.theta_pm(Soc_box0(i, j), physics.pressure(ice_thickness(i, j)));
+      double theta_pm = 273.15;
+      if (set_surface_pressure_limit) {
+        theta_pm = physics.theta_pm(Soc_box0(i, j), 0.0);
+      } else {
+        theta_pm = physics.theta_pm(Soc_box0(i, j), physics.pressure(ice_thickness(i, j)));
+      }
 
       // temperature input for grounding line box should not be below pressure melting point
       if (Toc_box0(i, j) < theta_pm) {

--- a/src/coupler/ocean/Pico.cc
+++ b/src/coupler/ocean/Pico.cc
@@ -142,7 +142,7 @@ void Pico::init_impl(const Geometry &geometry) {
   m_salinity_ocean->init(opt.filename, opt.periodic);
 
   // This initializes the basin_mask
-  m_geometry.init();
+  m_geometry.init(geometry.cell_type);
 
   // FIXME: m_n_basins is a misnomer
   m_n_basins = static_cast<int>(max(m_geometry.basin_mask())) + 1;

--- a/src/coupler/ocean/Pico.hh
+++ b/src/coupler/ocean/Pico.hh
@@ -76,6 +76,7 @@ private:
                               const IceModelVec2CellType &mask,
                               const IceModelVec2Int &basin_mask,
                               const IceModelVec2Int &shelf_mask,
+			      const IceModelVec2Int &isolated_basin_mask,
                               const std::vector<double> &basin_temperature,
                               const std::vector<double> &basin_salinity,
                               IceModelVec2S &Toc_box0,

--- a/src/coupler/ocean/PicoGeometry.cc
+++ b/src/coupler/ocean/PicoGeometry.cc
@@ -566,7 +566,7 @@ void PicoGeometry::compute_isolated_basin_mask(const IceModelVec2S &bed_elevatio
                                                double bed_elevation_threshold,
                                                IceModelVec2Int &result) {
 
-  IceModelVec::AccessList list{ &bed_elevation, &ice_rise_mask, &basin_mask, &m_tmp };
+  IceModelVec::AccessList list{ &bed_elevation, &ice_rise_mask, &basin_mask, &m_tmp, &result };
 
   //n_basins = static_cast<int>(max(basin_mask)) + 1;
 
@@ -616,9 +616,17 @@ void PicoGeometry::compute_isolated_basin_mask(const IceModelVec2S &bed_elevatio
 
       m_tmp.get_from_proc0(*m_tmp_p0);
     }
-  }
 
-  result.copy_from(m_tmp);
+    for (Points p(*m_grid); p; p.next()) {
+      const int i = p.i(), j = p.j();
+ 
+      // save isolated regions from previous b step as value 1
+      if (m_tmp(i, j) == 1.0 and basin_mask.as_int(i, j) == b) {
+        result(i, j) = 1.0;
+      }
+    }
+  }
+  //result.copy_from(m_tmp);
 }
 
 /*!

--- a/src/coupler/ocean/PicoGeometry.cc
+++ b/src/coupler/ocean/PicoGeometry.cc
@@ -124,9 +124,9 @@ void PicoGeometry::update(const IceModelVec2S &bed_elevation,
   // adjacent basins by iterating over the current ice front. This means that basin
   // adjacency cannot be pre-computed during initialization.
   //
-  bool update_pico_basin_neighbors = m_config->get_flag("ocean.pico.update_pico_basin_neighbors");
+  bool update_basin_neighbors = m_config->get_flag("ocean.pico.update_basin_neighbors");
 
-  if (update_pico_basin_neighbors) {
+  if (update_basin_neighbors) {
 
     m_basin_neighbors = basin_neighbors(cell_type, m_basin_mask);
 

--- a/src/coupler/ocean/PicoGeometry.cc
+++ b/src/coupler/ocean/PicoGeometry.cc
@@ -1,4 +1,4 @@
-/* Copyright (C) 2018, 2019, 2020, 2021 PISM Authors
+/* Copyright (C) 2018, 2019, 2020, 2021, 2022 PISM Authors
  *
  * This file is part of PISM.
  *
@@ -140,6 +140,21 @@ void PicoGeometry::update(const IceModelVec2S &bed_elevation,
       m_log->message(3, "PICO: update basin %d neighbors: %s\n",
                      p.first, neighbor_list.c_str());
     }
+  }
+
+  // Update m_basin_mask metadata to make sure that adjacency information is saved to the
+  // output file:
+  for (const auto &p : m_basin_neighbors) {
+    int basin = p.first;
+
+    // convert set<int> to vector<double>:
+    std::vector<double> neighbors{};
+    for (const auto &n : p.second) {
+      neighbors.emplace_back(n);
+    }
+
+    auto attr_name = pism::printf("basin_%02d_neighbors", basin);
+    m_basin_mask.metadata().set_numbers(attr_name, neighbors);
   }
 
   bool exclude_ice_rises = m_config->get_flag("ocean.pico.exclude_ice_rises");

--- a/src/coupler/ocean/PicoGeometry.hh
+++ b/src/coupler/ocean/PicoGeometry.hh
@@ -47,6 +47,7 @@ public:
   void update(const IceModelVec2S &bed_elevation, const IceModelVec2CellType &cell_type);
 
   const IceModelVec2Int &continental_shelf_mask() const;
+  const IceModelVec2Int &isolated_basin_mask() const;
   const IceModelVec2Int &box_mask() const;
   const IceModelVec2Int &ice_shelf_mask() const;
   const IceModelVec2Int &ice_rise_mask() const;
@@ -62,6 +63,12 @@ private:
                                       const IceModelVec2Int &ice_rise_mask,
                                       double bed_elevation_threshold,
                                       IceModelVec2Int &result);
+  void compute_isolated_basin_mask(const IceModelVec2S &bed_elevation,
+                                      const IceModelVec2Int &ice_rise_mask,
+                                      const IceModelVec2Int &basin_mask,
+                                      double bed_elevation_threshold,
+                                      IceModelVec2Int &result);
+
   void compute_ice_shelf_mask(const IceModelVec2Int &ice_rise_mask,
                               const IceModelVec2Int &lake_mask,
                               IceModelVec2Int &result);
@@ -75,6 +82,8 @@ private:
                                          int n_shelves,
                                          std::vector<int> &most_shelf_cells_in_basin,
                                          std::vector<int> &cfs_in_basins_per_shelf);
+
+
 
   void split_ice_shelves(const IceModelVec2CellType &cell_type,
                          const IceModelVec2Int &basin_mask,
@@ -105,6 +114,7 @@ private:
 
   // storage for outputs
   IceModelVec2Int m_continental_shelf;
+  IceModelVec2Int m_isolated_basin;
   IceModelVec2Int m_boxes;
   IceModelVec2Int m_ice_shelves;
   IceModelVec2Int m_basin_mask;

--- a/src/coupler/ocean/PicoGeometry.hh
+++ b/src/coupler/ocean/PicoGeometry.hh
@@ -43,7 +43,7 @@ public:
   PicoGeometry(IceGrid::ConstPtr grid);
   virtual ~PicoGeometry() = default;
 
-  void init();
+  void init(const IceModelVec2CellType &cell_type);
   void update(const IceModelVec2S &bed_elevation, const IceModelVec2CellType &cell_type);
 
   const IceModelVec2Int &continental_shelf_mask() const;

--- a/src/pism_config.cdl
+++ b/src/pism_config.cdl
@@ -1706,7 +1706,7 @@ netcdf pism_config {
     pism_config:ocean.pico.heat_exchange_coefficent_units = "meters second-1";
 
     pism_config:ocean.pico.limit_pressure_melting_at_surface = "no";
-    pism_config:ocean.pico.limit_pressure_melting_at_surface_doc = "If set to true, the lower limit of pressure melting point is set at surface pressure melting";
+    pism_config:ocean.pico.limit_pressure_melting_at_surface_doc = "If set to true, the lower limit for the PICO ocean input temperature is shifted from pressure melting point at grounding line depth to surface pressure melting point, assuming that the ocean water reaching the grounding line stems from the ocean surface or from warmer intermediate water masses.";
     pism_config:ocean.pico.limit_pressure_melting_at_surface_option = "pico_surf_pressure_melt";
     pism_config:ocean.pico.limit_pressure_melting_at_surface_type = "flag";
 

--- a/src/pism_config.cdl
+++ b/src/pism_config.cdl
@@ -1731,10 +1731,10 @@ netcdf pism_config {
     pism_config:ocean.pico.periodic_doc = "If true, interpret forcing data as periodic in time";
     pism_config:ocean.pico.periodic_type = "flag";
 
-    pism_config:ocean.pico.update_pico_basin_neighbors = "no";
-    pism_config:ocean.pico.update_pico_basin_neighbors_doc = "If set to true, PICO basin neighbors are computed in each time step according to current ice shelf front.";
-    pism_config:ocean.pico.update_pico_basin_neighbors_option = "update_pico_neighbors";
-    pism_config:ocean.pico.update_pico_basin_neighbors_type = "flag";
+    pism_config:ocean.pico.update_basin_neighbors = "no";
+    pism_config:ocean.pico.update_basin_neighbors_doc = "If set to true, PICO basin neighbors are computed in each time step according to current ice shelf front.";
+    pism_config:ocean.pico.update_basin_neighbors_option = "update_pico_neighbors";
+    pism_config:ocean.pico.update_basin_neighbors_type = "flag";
 
     pism_config:ocean.pik_melt_factor = 5e-3;
     pism_config:ocean.pik_melt_factor_doc = "dimensionless tuning parameter in the ``-ocean pik`` ocean heat flux parameterization; see :cite:`Martinetal2011`";

--- a/src/pism_config.cdl
+++ b/src/pism_config.cdl
@@ -1726,6 +1726,11 @@ netcdf pism_config {
     pism_config:ocean.pico.periodic_doc = "If true, interpret forcing data as periodic in time";
     pism_config:ocean.pico.periodic_type = "flag";
 
+    pism_config:ocean.pico.update_pico_basin_neighbors = "no";
+    pism_config:ocean.pico.update_pico_basin_neighbors_doc = "If set to true, PICO basin neighbors are computed in each time step according to current ice shelf front.";
+    pism_config:ocean.pico.update_pico_basin_neighbors_option = "update_pico_neighbors";
+    pism_config:ocean.pico.update_pico_basin_neighbors_type = "flag";
+
     pism_config:ocean.pik_melt_factor = 5e-3;
     pism_config:ocean.pik_melt_factor_doc = "dimensionless tuning parameter in the ``-ocean pik`` ocean heat flux parameterization; see :cite:`Martinetal2011`";
     pism_config:ocean.pik_melt_factor_option = "meltfactor_pik";

--- a/src/pism_config.cdl
+++ b/src/pism_config.cdl
@@ -1705,6 +1705,11 @@ netcdf pism_config {
     pism_config:ocean.pico.heat_exchange_coefficent_type = "number";
     pism_config:ocean.pico.heat_exchange_coefficent_units = "meters second-1";
 
+    pism_config:ocean.pico.limit_pressure_melting_at_surface = "no";
+    pism_config:ocean.pico.limit_pressure_melting_at_surface_doc = "If set to true, the lower limit of pressure melting point is set at surface pressure melting";
+    pism_config:ocean.pico.limit_pressure_melting_at_surface_option = "pico_surf_pressure_melt";
+    pism_config:ocean.pico.limit_pressure_melting_at_surface_type = "flag";
+
     pism_config:ocean.pico.maximum_ice_rise_area = 1e5;
     pism_config:ocean.pico.maximum_ice_rise_area_doc = "Specifies an area threshold that separates ice rises from continental regions.";
     pism_config:ocean.pico.maximum_ice_rise_area_type = "number";


### PR DESCRIPTION
This code adds 
1) PICO functionality in the case of ice shelves, that are confined within basins, that have no direct access to the open ocean. Those isolated basin regions are identified using the connected component method, but for each basin number individually, which may come with quite some cost?!
2) Also, PICO basin neighbors (and non-neighbors) are calculated only once at init per default, and not during every update any more (optional).
3) The lower bound for ocean input temperatures for PICO can be optionally set to pressure melting point, assuming that there is no process cooling ocean waters on their way to the grounding line.


**Checklist**

- [x] update documentation
- [x] update [`CHANGES.rst`](CHANGES.rst)
- [x] add regression tests
