### PR TITLE
Add CITATIONS.cff

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -29,3 +29,4 @@ Enrico Degregori <degregori@dkrz.de>                k202136 <k202136@mlogin103.h
 Enrico Degregori <degregori@dkrz.de>                k202136 <k202136@mlogin104.hpc.dkrz.de>
 Enrico Degregori <degregori@dkrz.de>                k202136 <k202136@mlogin105.hpc.dkrz.de>
 Enrico Degregori <degregori@dkrz.de>                k202136 <k202136@mlogin108.hpc.dkrz.de>
+Moritz Kreuzer <kreuzer@pik-potsdam.de>

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,6 +11,9 @@ message: >-
   metadata from this file.
 type: software
 doi: 10.5281/zenodo.1199019
+contact:
+  - email: uaf-pism@alaska.edu
+    name: "PISM developers at UAF"
 authors:
   - given-names: Constantine
     family-names: Khrulev

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,74 @@
+# -*- mode: yaml -*-
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+#
+# Run "git shortlog -sn" to list some authors
+
+cff-version: 1.2.0
+title: 'Parallel Ice Sheet Model (PISM)'
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: Constantine
+    family-names: Khrulev
+    email: ckhroulev@alaska.edu
+    affiliation: University of Alaska Fairbanks
+    orcid: 'https://orcid.org/0000-0003-2170-7454'
+  - given-names: Andy
+    family-names: Aschwanden
+    email: aaschwanden@alaska.edu
+    affiliation: University of Alaska Fairbanks
+    orcid: 'https://orcid.org/0000-0001-8149-2315'
+  - given-names: Ed
+    family-names: Bueler
+    email: elbueler@alaska.edu
+    affiliation: University of Alaska Fairbanks
+    orcid: 'https://orcid.org/0000-0001-8232-4145'
+  - given-names: David
+    family-names: Maxwell
+    email: damaxwell@alaska.edu
+    affiliation: University of Alaska Fairbanks
+  - given-names: Torsten
+    family-names: Albrecht
+    email: albrecht@pik-potsdam.de
+    affiliation: Potsdam Institute for Climate Impact Research (PIK)
+    orcid: 'https://orcid.org/0000-0001-7459-2860'
+  - given-names: Jed
+    family-names: Brown
+    email: jed@jedbrown.org
+    affiliation: University of Colorado Boulder
+    orcid: 'https://orcid.org/0000-0002-9945-0639'
+  - given-names: Ronja
+    family-names: Reese
+    affiliation: University of Northumbria at Newcastle
+    orcid: 'https://orcid.org/0000-0001-7625-040X'
+  - given-names: Ricarda
+    family-names: Winkelmann
+    affiliation: Potsdam Institute for Climate Impact Research (PIK)
+    orcid: 'https://orcid.org/0000-0003-1248-3217'
+  - given-names: Matthias
+    family-names: Mengel
+    affiliation: Potsdam Institute for Climate Impact Research (PIK)
+    orcid: 'https://orcid.org/0000-0001-6724-9685'
+
+repository-code: 'https://github.com/pism/pism/'
+url: 'https://www.pism.io'
+
+abstract: The Parallel Ice Sheet Model (PISM) is an open-source modelling framework for
+  ice sheets and glaciers. Its features include a hierarchy of available stress balances,
+  marine ice sheet physics with dynamic calving fronts, an enthalpy-based conservation of
+  energy scheme, bed deformation and subglacial hydrology components, extensible coupling
+  to atmospheric and ocean models, and comprehensive user documentation. PISM uses
+  distributed-memory (PETSc- and MPI-based) parallelism for high-resolution simulations.
+
+  PISM is jointly developed at the University of Alaska, Fairbanks (UAF) and the Potsdam
+  Institute for Climate Impact Research (PIK).
+
+keywords:
+  - ice sheet model
+  - open source
+  - geophysics
+  - sea level
+license: GPL-3.0+

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,6 +10,7 @@ message: >-
   If you use this software, please cite it using the
   metadata from this file.
 type: software
+doi: 10.5281/zenodo.1199019
 authors:
   - given-names: Constantine
     family-names: Khrulev

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -71,4 +71,4 @@ keywords:
   - open source
   - geophysics
   - sea level
-license: GPL-3.0+
+license: GPL-3.0-or-later

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,7 +4,7 @@
 #
 # git shortlog -sn --no-merges `branch`
 #
-# to list contributors to a `branch`.
+# to list contributors to a `branch` and the number of non-merge commits they made.
 #
 # Output as of 2023-10-25 (branch=dev)
 #
@@ -55,13 +55,21 @@
 #
 # Overall total: 32
 #
-# To validate this, install `cffconvert`
+# To validate this document, install `cffconvert`
 #
 # python3 -m pip install cffconvert --user
 #
 # and run
 #
 # cffconvert --validate
+#
+# Note: the CITATION.cff format does not allow for extra information, so
+# "contribution-areas" below are commented out. These lines *are* needed to generate the
+# list of authors in the manual, though. Each author should have a list of contribution
+# areas *one one line*, indented so that the substitution "s/# contrib/contrib/g" will
+# produce a valid YAML document.
+#
+# See doc/sphinx/Makefile and doc/sphinx/authorship.py for details.
 
 cff-version: 1.2.0
 title: 'Parallel Ice Sheet Model (PISM)'
@@ -89,8 +97,7 @@ authors:
     email: elbueler@alaska.edu
     affiliation: University of Alaska Fairbanks
     orcid: 'https://orcid.org/0000-0001-8232-4145'
-    # contribution-areas: former project leader, verification, earth deformation,
-    # numerics, thermodynamics, documentation
+    # contribution-areas: former project leader, verification, earth deformation, numerics, thermodynamics, documentation
   - given-names: Jed
     family-names: Brown
     affiliation: University of Colorado Boulder
@@ -121,8 +128,7 @@ authors:
     family-names: Martin
     affiliation: Potsdam Institute for Climate Impact Research (PIK)
     orcid: 'https://orcid.org/0000-0002-1443-0891'
-    # contribution-areas: SeaRISE-Antarctica, Antarctic mean annual temperature
-    # parameterization, sub-shelf processes
+    # contribution-areas: SeaRISE-Antarctica, Antarctic mean annual temperature parameterization, sub-shelf processes
   - given-names: Ricarda
     family-names: Winkelmann
     affiliation: Potsdam Institute for Climate Impact Research (PIK)
@@ -195,8 +201,7 @@ authors:
   - given-names: Nathan
     family-names: Shemonski
     affiliation: Zoox, Inc
-    # contribution-areas: documentation, scripts and code related to the pre-v0.1 EISMINT
-    # Greenland setup
+    # contribution-areas: documentation, scripts and code related to the pre-v0.1 EISMINT Greenland setup
   - given-names: Kenneth
     family-names: Mankoff
     affiliation: Goddard Institute for Space Studies
@@ -237,7 +242,7 @@ authors:
   - given-names: Simon
     family-names: Schoell
     affiliation: Potsdam Institute for Climate Impact Research (PIK)
-    # contribution-areas: bug fix calving
+    # contribution-areas: calving bug fix
 
 repository-code: 'https://github.com/pism/pism/'
 url: 'https://www.pism.io'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,14 +1,71 @@
 # -*- mode: yaml -*-
-# This CITATION.cff file was generated with cffinit.
-# Visit https://bit.ly/cffinit to generate yours today!
 #
-# Run "git shortlog -sn" to list some authors
+# Run
+#
+# git shortlog -sn --no-merges `branch`
+#
+# to list contributors to a `branch`.
+#
+# Output as of 2023-10-25 (branch=dev)
+#
+# 6981  Constantine Khrulev
+# 1856  Ed Bueler
+#  360  Andy Aschwanden
+#  272  David Maxwell
+#  126  Torsten Albrecht
+#   86  Jed Brown
+#   47  Maria Zeitz
+#   30  Julien Seguinot
+#   22  Elizabeth Fischer
+#   18  Matthias Mengel
+#   13  Maria Martin
+#   13  Nathan Shemonski
+#   10  Anders Damsgaard
+#    4  Sebastian Hinck
+#    2  Enrico Degregori
+#    2  Florian Ziemen
+#    2  Joseph H Kennedy
+#    2  Ronja Reese
+#    2  Thomas Kleiner
+#    1  Johannes Feldmann
+#    1  Ken Mankoff
+#    1  Kyle Blum
+#    1  Marijke Habermann
+#    1  Simon Schöll
+#
+# Running it with branch=main also adds
+#
+#    1  Moritz Kreuzer
+#    1  DeepSource Bot
+#
+# Total: 25, not counting the bot.
+#
+# Authors who are not listed above but are known to have made a contribution:
+#
+# Anders Levermann
+# Craig Lingle
+# Daniella DellaGiustina
+# Julius Garbe
+# Marianne Haseloff
+# Regine Hock
+# Ricarda Winkelmann
+# Ward van Pelt
+#
+# Total: 7
+#
+# Overall total: 32
+#
+# To validate this, install `cffconvert`
+#
+# python3 -m pip install cffconvert --user
+#
+# and run
+#
+# cffconvert --validate
 
 cff-version: 1.2.0
 title: 'Parallel Ice Sheet Model (PISM)'
-message: >-
-  If you use this software, please cite it using the
-  metadata from this file.
+message: "If you use this software, please cite it using the metadata from this file."
 type: software
 doi: 10.5281/zenodo.1199019
 contact:
@@ -20,42 +77,167 @@ authors:
     email: ckhroulev@alaska.edu
     affiliation: University of Alaska Fairbanks
     orcid: 'https://orcid.org/0000-0003-2170-7454'
+    # contribution-areas: primary source code author, software design, numerics, input/output, higher-order stress balance, mass conservation, verification, documentation, testing, user support, maintenance, ...
   - given-names: Andy
     family-names: Aschwanden
     email: aaschwanden@alaska.edu
     affiliation: University of Alaska Fairbanks
     orcid: 'https://orcid.org/0000-0001-8149-2315'
+    # contribution-areas: project leader, thermodynamics, testing, user support, visualization, etc
   - given-names: Ed
     family-names: Bueler
     email: elbueler@alaska.edu
     affiliation: University of Alaska Fairbanks
     orcid: 'https://orcid.org/0000-0001-8232-4145'
+    # contribution-areas: former project leader, verification, earth deformation,
+    # numerics, thermodynamics, documentation
+  - given-names: Jed
+    family-names: Brown
+    affiliation: University of Colorado Boulder
+    orcid: 'https://orcid.org/0000-0002-9945-0639'
+    # contribution-areas: source code original author, SSA numerics, parallelism using PETSc, etc
   - given-names: David
     family-names: Maxwell
     email: damaxwell@alaska.edu
     affiliation: University of Alaska Fairbanks
+    # contribution-areas: inverse methods, SSA finite element solver, Python bindings
   - given-names: Torsten
     family-names: Albrecht
     email: albrecht@pik-potsdam.de
     affiliation: Potsdam Institute for Climate Impact Research (PIK)
     orcid: 'https://orcid.org/0000-0001-7459-2860'
-  - given-names: Jed
-    family-names: Brown
-    email: jed@jedbrown.org
-    affiliation: University of Colorado Boulder
-    orcid: 'https://orcid.org/0000-0002-9945-0639'
+    # contribution-areas: ice shelf physics and numerics
   - given-names: Ronja
     family-names: Reese
     affiliation: University of Northumbria at Newcastle
     orcid: 'https://orcid.org/0000-0001-7625-040X'
-  - given-names: Ricarda
-    family-names: Winkelmann
-    affiliation: Potsdam Institute for Climate Impact Research (PIK)
-    orcid: 'https://orcid.org/0000-0003-1248-3217'
+    # contribution-areas: sub-shelf mass balance (PICO), ice shelf numerics, etc
   - given-names: Matthias
     family-names: Mengel
     affiliation: Potsdam Institute for Climate Impact Research (PIK)
     orcid: 'https://orcid.org/0000-0001-6724-9685'
+    # contribution-areas: ice shelf physics (PICO)
+  - given-names: Maria
+    family-names: Martin
+    affiliation: Potsdam Institute for Climate Impact Research (PIK)
+    orcid: 'https://orcid.org/0000-0002-1443-0891'
+    # contribution-areas: SeaRISE-Antarctica, Antarctic mean annual temperature
+    # parameterization, sub-shelf processes
+  - given-names: Ricarda
+    family-names: Winkelmann
+    affiliation: Potsdam Institute for Climate Impact Research (PIK)
+    orcid: 'https://orcid.org/0000-0003-1248-3217'
+    # contribution-areas: sub-shelf mass balance (PICO), Antarctica processes, coupling, modeling, etc
+  - given-names: Maria
+    family-names: Zeitz
+    affiliation: Potsdam Institute for Climate Impact Research (PIK)
+    orcid: 'https://orcid.org/0000-0001-8129-1329'
+    # contribution-areas: surface processes (dEBM-simple)
+  - given-names: Anders
+    family-names: Levermann
+    affiliation: Potsdam Institute for Climate Impact Research (PIK)
+    orcid: 'https://orcid.org/0000-0003-4432-4704'
+    # contribution-areas: ice shelf dynamics theory, calving, etc
+  - given-names: Johannes
+    family-names: Feldmann
+    orcid: 'https://orcid.org/0000-0003-4210-0221'
+    affiliation: Potsdam Institute for Climate Impact Research (PIK)
+    # contribution-areas: marine ice sheet processes, grounding line dynamics
+  - given-names: Julius
+    family-names: Garbe
+    orcid: 'https://orcid.org/0000-0003-3140-3307'
+    affiliation: Potsdam Institute for Climate Impact Research (PIK)
+    # contribution-areas: surface mass and energy balance (dEBM-simple)
+  - given-names: Marianne
+    family-names: Haseloff
+    affiliation: University of Wisconsin-Madison
+    orcid: 'https://orcid.org/0000-0002-6576-5384'
+    # contribution-areas: PISM-PIK development, SSA and SIA theory and numerics
+  - given-names: Julien
+    family-names: Seguinot
+    affiliation: University of Bergen
+    orcid: 'https://orcid.org/0000-0002-5315-0761'
+    # contribution-areas: improvements to the temperature index (PDD) model
+  - given-names: Sebastian
+    family-names: Hinck
+    affiliation: Deutsches Klimarechenzentrum GmbH
+    orcid: 'https://orcid.org/0000-0002-6428-305X'
+    # contribution-areas: improvements to the Lingle-Clark bed deformation model
+  - given-names: Thomas
+    family-names: Kleiner
+    affiliation: Alfred Wegener Institute Helmholtz Centre for Polar and Marine Research
+    orcid: 'https://orcid.org/0000-0001-7825-5765'
+    # contribution-areas: bug fixes in the enthalpy model
+  - given-names: Elizabeth
+    family-names: Fischer
+    affiliation: University of Alaska Fairbanks
+    orcid: 'https://orcid.org/0000-0002-3987-2696'
+    # contribution-areas: bug fixes, coupling to a GCM
+  - given-names: Anders
+    family-names: Damsgaard
+    affiliation: Aarhus University
+    orcid: 'https://orcid.org/0000-0002-9284-1709'
+    # contribution-areas: automatic testing
+  - given-names: Craig
+    family-names: Lingle
+    affiliation: University of Alaska Fairbanks
+    # contribution-areas: original SIA model, earth deformation
+  - given-names: Ward
+    family-names: van Pelt
+    affiliation: Uppsala Universitet
+    orcid: 'https://orcid.org/0000-0003-4839-7900'
+    # contribution-areas: subglacial hydrology analysis and design
+  - given-names: Florian
+    family-names: Ziemen
+    orcid: 'https://orcid.org/0000-0001-7095-5740'
+    affiliation: Deutsches Klimarechenzentrum GmbH
+    # contribution-areas: bug fix in the interpolation code
+  - given-names: Nathan
+    family-names: Shemonski
+    affiliation: Zoox, Inc
+    # contribution-areas: documentation, scripts and code related to the pre-v0.1 EISMINT
+    # Greenland setup
+  - given-names: Kenneth
+    family-names: Mankoff
+    affiliation: Goddard Institute for Space Studies
+    orcid: 'https://orcid.org/0000-0001-5453-2019'
+    # contribution-areas: documentation
+  - given-names: Joseph
+    family-names: Kennedy
+    affiliation: University of Alaska Fairbanks
+    orcid: 'https://orcid.org/0000-0002-9348-693X'
+    # contribution-areas: documentation
+  - given-names: Kyle
+    family-names: Blum
+    affiliation: University of Alaska Fairbanks
+    # contribution-areas: bug fix in the SeaRISE-Antarctica setup
+  - given-names: Marijke
+    family-names: Habermann
+    affiliation: University of Alaska Fairbanks
+    # contribution-areas: inverse modeling
+  - given-names: Daniella
+    family-names: DellaGiustina
+    affiliation: University of Arizona
+    orcid: 'https://orcid.org/0000-0002-5643-1956'
+    # contribution-areas: regional modeling
+  - given-names: Regine
+    family-names: Hock
+    affiliation: University of Oslo
+    orcid: 'https://orcid.org/0000-0001-8336-9441'
+    # contribution-areas: surface mass and energy balance
+  - given-names: Moritz
+    family-names: Kreuzer
+    affiliation: Potsdam Institute for Climate Impact Research (PIK)
+    orcid: 'https://orcid.org/0000-0002-8622-6638'
+    # contribution-areas: Python 3.8+ compatibility
+  - given-names: Enrico
+    family-names: Degregori
+    affiliation: Deutsches Klimarechenzentrum GmbH
+    # contribution-areas: PICO optimization
+  - given-names: Simon
+    family-names: Schoell
+    affiliation: Potsdam Institute for Climate Impact Research (PIK)
+    # contribution-areas: bug fix calving
 
 repository-code: 'https://github.com/pism/pism/'
 url: 'https://www.pism.io'

--- a/doc/sphinx/Makefile
+++ b/doc/sphinx/Makefile
@@ -1,6 +1,6 @@
 # Run "make all" to update lists of diagnostics and configuration parameters.
 
-all: update_diagnostics installation/code/install_libraries.sh
+all: update_diagnostics update_authorship installation/code/install_libraries.sh
 
 INTERMEDIATE=diag.json diag-2.json dummy.nc pism_config.nc surface_input.nc
 
@@ -66,6 +66,9 @@ diag.json: dummy.nc surface_input.nc
 # matters here)
 update_diagnostics: diag.json diag-2.json
 	python3 ./list_diagnostics.py $^ > manual/diagnostics/diagnostics-list.txt
+
+update_authorship: ../../CITATION.cff
+	sed "s/# contrib/contrib/g" $^ | python3 authorship.py > authorship.rst
 
 pism_config.nc: ../../src/pism_config.cdl
 	ncgen -o $@ $^

--- a/doc/sphinx/authorship.py
+++ b/doc/sphinx/authorship.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+import yaml
+import sys
+
+print(""".. DO NOT EDIT. Update CITATION.cff to add more authors and see `authorship.py`.
+
+.. include:: global.txt
+
+.. include:: <isonum.txt>
+
+Authorship
+==========
+
+   *Copyright* |copy| *2004 -- 2023 the PISM authors.*
+
+   *This file is part of PISM. PISM is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License as published by the Free
+   Software Foundation; either version 3 of the License, or (at your option) any later
+   version. PISM is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+   PARTICULAR PURPOSE. See the GNU General Public License for more details. You should
+   have received a copy of the GNU General Public License along with PISM. If not, write
+   to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+   02110-1301 USA*
+
+PISM is a joint project between developers in the ice sheet modeling group at the
+University of Alaska (UAF), developers at the Potsdam Institute for Climate Impact
+Research (PIK), and several additional developers listed here.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 1,1
+
+   * - Name and affiliation
+     - Areas of contribution""")
+
+for author in yaml.safe_load(sys.stdin)["authors"]:
+    name = f"{author['given-names']} {author['family-names']}"
+    try:
+        name = f"`{name} <{author['orcid']}>`_"
+    except KeyError:
+        pass
+    print(f"""
+   * - {name} ({author['affiliation']})
+     - {author['contribution-areas']}""")

--- a/doc/sphinx/authorship.rst
+++ b/doc/sphinx/authorship.rst
@@ -1,3 +1,5 @@
+.. DO NOT EDIT. Update CITATION.cff to add more authors and see `authorship.py`.
+
 .. include:: global.txt
 
 .. include:: <isonum.txt>
@@ -5,7 +7,7 @@
 Authorship
 ==========
 
-   *Copyright* |copy| *2004 -- 2022 the PISM authors.*
+   *Copyright* |copy| *2004 -- 2023 the PISM authors.*
 
    *This file is part of PISM. PISM is free software; you can redistribute it and/or
    modify it under the terms of the GNU General Public License as published by the Free
@@ -23,56 +25,106 @@ Research (PIK), and several additional developers listed here.
 
 .. list-table::
    :header-rows: 1
-   :widths: 1,2
+   :widths: 1,1
 
    * - Name and affiliation
-     - Area of contribution
-   * - Torsten Albrecht (PIK)
-     - ice shelf physics and numerics 
-   * - **Andy Aschwanden** (UAF)
-     - scripts, visualization, thermodynamics, SeaRISE-Greenland
-   * - Jed Brown (ANL)
-     - source code original author, SSA numerics, PETSc underpinnings 
-   * - **Ed Bueler** (UAF)
-     - former principal investigator, verification, earth deformation, SIA numerics,
-       thermodynamics, documentation
-   * - Dani DellaGiustina (UAF)
-     - regional tools and modeling 
-   * - Johannes Feldman (PIK)
-     - marine ice sheet processes 
-   * - Elizabeth Fischer (GFDL)
-     - coupling design 
-   * - Marijke Habermann (UAF)
-     - inversion
-   * - Marianne Haseloff (UBC)
-     - ice streams: physics and numerics
-   * - Regine Hock (UAF)
-     - surface mass and energy balance 
-   * - **Constantine Khrulev** (UAF)
-     - source code primary author, input/output, software design, climate couplers,
-       higher-order stress balance, parallelization, testing, user support, most
-       documentation, most bug fixes, regional tools, ...
-   * - Anders Levermann (PIK)
-     - calving, ice shelf processes 
-   * - Craig Lingle (UAF)
-     - original SIA model, earth deformation 
-   * - Maria Martin (PIK)
-     - SeaRISE-Antarctica, Antarctica processes 
-   * - Mattias Mengel (PIK)
-     - marine ice sheet processes 
-   * - David Maxwell (UAF)
-     - inversion, SSA finite elements, Python bindings
-   * - Ward van Pelt (IMAU)
-     - subglacial hydrology analysis and design
-   * - Ronja Reese (PIK)
-     - sub-shelf mass balance, ice shelf numerics, bug fixes
-   * - Julien Seguinot (ETH)
-     - bug fixes, temperature index model 
-   * - Ricarda Winkelmann (PIK)
-     - Antarctica processes, coupling, and modeling
-   * - Maria Zeitz (PIK)
-     - surface mass and energy balance
-   * - Florian Ziemen (MPI)
-     - bug fixes, sliding 
+     - Areas of contribution
 
-Email the **highlighted** UAF developers at |pism-email|.
+   * - `Constantine Khrulev <https://orcid.org/0000-0003-2170-7454>`_ (University of Alaska Fairbanks)
+     - primary source code author, software design, numerics, input/output, higher-order stress balance, mass conservation, verification, documentation, testing, user support, maintenance, ...
+
+   * - `Andy Aschwanden <https://orcid.org/0000-0001-8149-2315>`_ (University of Alaska Fairbanks)
+     - project leader, thermodynamics, testing, user support, visualization, etc
+
+   * - `Ed Bueler <https://orcid.org/0000-0001-8232-4145>`_ (University of Alaska Fairbanks)
+     - former project leader, verification, earth deformation, numerics, thermodynamics, documentation
+
+   * - `Jed Brown <https://orcid.org/0000-0002-9945-0639>`_ (University of Colorado Boulder)
+     - source code original author, SSA numerics, parallelism using PETSc, etc
+
+   * - David Maxwell (University of Alaska Fairbanks)
+     - inverse methods, SSA finite element solver, Python bindings
+
+   * - `Torsten Albrecht <https://orcid.org/0000-0001-7459-2860>`_ (Potsdam Institute for Climate Impact Research (PIK))
+     - ice shelf physics and numerics
+
+   * - `Ronja Reese <https://orcid.org/0000-0001-7625-040X>`_ (University of Northumbria at Newcastle)
+     - sub-shelf mass balance (PICO), ice shelf numerics, etc
+
+   * - `Matthias Mengel <https://orcid.org/0000-0001-6724-9685>`_ (Potsdam Institute for Climate Impact Research (PIK))
+     - ice shelf physics (PICO)
+
+   * - `Maria Martin <https://orcid.org/0000-0002-1443-0891>`_ (Potsdam Institute for Climate Impact Research (PIK))
+     - SeaRISE-Antarctica, Antarctic mean annual temperature parameterization, sub-shelf processes
+
+   * - `Ricarda Winkelmann <https://orcid.org/0000-0003-1248-3217>`_ (Potsdam Institute for Climate Impact Research (PIK))
+     - sub-shelf mass balance (PICO), Antarctica processes, coupling, modeling, etc
+
+   * - `Maria Zeitz <https://orcid.org/0000-0001-8129-1329>`_ (Potsdam Institute for Climate Impact Research (PIK))
+     - surface processes (dEBM-simple)
+
+   * - `Anders Levermann <https://orcid.org/0000-0003-4432-4704>`_ (Potsdam Institute for Climate Impact Research (PIK))
+     - ice shelf dynamics theory, calving, etc
+
+   * - `Johannes Feldmann <https://orcid.org/0000-0003-4210-0221>`_ (Potsdam Institute for Climate Impact Research (PIK))
+     - marine ice sheet processes, grounding line dynamics
+
+   * - `Julius Garbe <https://orcid.org/0000-0003-3140-3307>`_ (Potsdam Institute for Climate Impact Research (PIK))
+     - surface mass and energy balance (dEBM-simple)
+
+   * - `Marianne Haseloff <https://orcid.org/0000-0002-6576-5384>`_ (University of Wisconsin-Madison)
+     - PISM-PIK development, SSA and SIA theory and numerics
+
+   * - `Julien Seguinot <https://orcid.org/0000-0002-5315-0761>`_ (University of Bergen)
+     - improvements to the temperature index (PDD) model
+
+   * - `Sebastian Hinck <https://orcid.org/0000-0002-6428-305X>`_ (Deutsches Klimarechenzentrum GmbH)
+     - improvements to the Lingle-Clark bed deformation model
+
+   * - `Thomas Kleiner <https://orcid.org/0000-0001-7825-5765>`_ (Alfred Wegener Institute Helmholtz Centre for Polar and Marine Research)
+     - bug fixes in the enthalpy model
+
+   * - `Elizabeth Fischer <https://orcid.org/0000-0002-3987-2696>`_ (University of Alaska Fairbanks)
+     - bug fixes, coupling to a GCM
+
+   * - `Anders Damsgaard <https://orcid.org/0000-0002-9284-1709>`_ (Aarhus University)
+     - automatic testing
+
+   * - Craig Lingle (University of Alaska Fairbanks)
+     - original SIA model, earth deformation
+
+   * - `Ward van Pelt <https://orcid.org/0000-0003-4839-7900>`_ (Uppsala Universitet)
+     - subglacial hydrology analysis and design
+
+   * - `Florian Ziemen <https://orcid.org/0000-0001-7095-5740>`_ (Deutsches Klimarechenzentrum GmbH)
+     - bug fix in the interpolation code
+
+   * - Nathan Shemonski (Zoox, Inc)
+     - documentation, scripts and code related to the pre-v0.1 EISMINT Greenland setup
+
+   * - `Kenneth Mankoff <https://orcid.org/0000-0001-5453-2019>`_ (Goddard Institute for Space Studies)
+     - documentation
+
+   * - `Joseph Kennedy <https://orcid.org/0000-0002-9348-693X>`_ (University of Alaska Fairbanks)
+     - documentation
+
+   * - Kyle Blum (University of Alaska Fairbanks)
+     - bug fix in the SeaRISE-Antarctica setup
+
+   * - Marijke Habermann (University of Alaska Fairbanks)
+     - inverse modeling
+
+   * - `Daniella DellaGiustina <https://orcid.org/0000-0002-5643-1956>`_ (University of Arizona)
+     - regional modeling
+
+   * - `Regine Hock <https://orcid.org/0000-0001-8336-9441>`_ (University of Oslo)
+     - surface mass and energy balance
+
+   * - `Moritz Kreuzer <https://orcid.org/0000-0002-8622-6638>`_ (Potsdam Institute for Climate Impact Research (PIK))
+     - Python 3.8+ compatibility
+
+   * - Enrico Degregori (Deutsches Klimarechenzentrum GmbH)
+     - PICO optimization
+
+   * - Simon Schoell (Potsdam Institute for Climate Impact Research (PIK))
+     - calving bug fix


### PR DESCRIPTION
We should add `CITATIONS.cff` (see https://citation-file-format.github.io/) to make it easier to properly cite particular PISM versions (it will be used by Zenodo when it archives PISM releases).

The important task here is listing everyone who made a significant contribution. Some (more obvious) contributions can be tracked using Git (see https://github.com/pism/pism/graphs/contributors and the output of `git shortlog -sn -- src/` below). Some co-authors, however, may not have committed much code themselves -- but they should still get credit.

I'm opening this PR so that you (the reader) can help me ensure that the list of authors in `CITATIONS.cff` is accurate. Thanks!

```
~/github/pism/pism$ git shortlog -sn -- src/
  5217  Constantine Khrulev
  1160  Ed Bueler
   220  Andy Aschwanden
   190  David Maxwell
   100  Torsten Albrecht
    77  Jed Brown
    19  Elizabeth Fischer
    16  Matthias Mengel
    13  Julien Seguinot
    11  Nathan Shemonski
     6  Maria Martin
     3  Sebastian Hinck
     2  Enrico Degregori
     2  Florian Ziemen
     2  Thomas Kleiner
     1  Johannes Feldmann
     1  Ronja Reese
     1  Simon Schöll
```

Note 1: We need to make sure that all authors of *small* contributions are mentioned in *acknowledgements* in the manual.
Note 2: Other suggestions, edits, etc are welcome.