### PR TITLE
Clarify software citation and style improvements in README.rst

### DIFF
--- a/ACKNOWLEDGE.rst
+++ b/ACKNOWLEDGE.rst
@@ -23,7 +23,10 @@ Citing
 ------
 
 To cite PISM please use at least one of Bueler and Brown (2009) or Winkelmann et al.
-(2011), below, as appropriate to the application.
+(2011), below, as appropriate to the application. Also cite PISM as a software as
+specified in the file `CITATION.cff <https://github.com/pism/pism/blob/main/CITATION.cff>`_,
+or check the 'Cite this repository' link in the sidebar of PISM's `github
+repository <https://github.com/pism/pism>`_.
 
 Do not forget to specify the PISM *version* you use. If your results came from source code
 modifications to PISM then we request that your publication say so explicitly.

--- a/README.rst
+++ b/README.rst
@@ -4,23 +4,23 @@ PISM, a Parallel Ice Sheet Model
 
 
 
-The Parallel Ice Sheet Model is an open source, parallel, high-resolution ice sheet model:
+The Parallel Ice Sheet Model is an open source, parallel, high-resolution ice sheet model that includes:
 
-- hierarchy of available stress balances
-- marine ice sheet physics, dynamic calving fronts
-- polythermal, enthalpy-based conservation of energy scheme
-- extensible coupling to atmospheric and ocean models
-- verification and validation tools
-- `documentation <pism-manual_>`_ for users and developers
-- uses MPI_ and PETSc_ for parallel simulations
-- reads and writes `CF-compliant <cf_>`_  NetCDF_ files
+- A hierarchy of available stress balances
+- Marine ice sheet physics, dynamic calving fronts
+- A polythermal, enthalpy-based conservation of energy scheme
+- Extensible coupling to atmospheric and ocean models
+- Verification and validation tools
+- `Documentation <pism-manual_>`_ for users and developers
+- Links to MPI_ and PETSc_ for parallel simulations
+- Use of `CF-compliant <cf_>`_  NetCDF_ files for input and output
 
 PISM is jointly developed at the `University of Alaska, Fairbanks (UAF) <uaf_>`_ and the
 `Potsdam Institute for Climate Impact Research (PIK) <pik_>`_. UAF developers are based in
 the `Glaciers Group <glaciers_>`_ at the `Geophysical Institute <gi_>`_.
 
-Please see ``ACKNOWLEDGE.rst`` and ``doc/funding.csv`` for a list of grants supporting
-PISM development.
+Please see ``ACKNOWLEDGE.rst`` and ``doc/funding.csv`` for how to acknowledge the use of PISM
+and a list of grants supporting PISM development.
 
 Homepage
 --------
@@ -30,7 +30,7 @@ Homepage
 Download and Install
 --------------------
 
-See the `Installing PISM <pism-installation_>`_ on ``pism.io``.
+See the section `Installing PISM <pism-installation_>`_ on ``pism.io``.
 
 Support
 -------

--- a/doc/acknowledge.py
+++ b/doc/acknowledge.py
@@ -24,7 +24,10 @@ Citing
 ------
 
 To cite PISM please use at least one of Bueler and Brown (2009) or Winkelmann et al.
-(2011), below, as appropriate to the application.
+(2011), below, as appropriate to the application. Also cite PISM as a software as
+specified in the file `CITATION.cff <https://github.com/pism/pism/blob/main/CITATION.cff>`_,
+or check the 'Cite this repository' link in the sidebar of PISM's `github
+repository <https://github.com/pism/pism>`_.
 
 Do not forget to specify the PISM *version* you use. If your results came from source code
 modifications to PISM then we request that your publication say so explicitly.


### PR DESCRIPTION
I am currently looking through the PISM repo to check its compatibility with the software best practices of the [Computational Infrastructure for Geodynamics](https://geodynamics.org/): https://geodynamics.org/software/software-bp

I am very impressed by the state of the repository, but I was confused for a bit about how to cite the software. That is because the README.rst does not really explain how to cite PISM, and the ACKNOWLEDGE.rst and CITATION.cff seem to contradict each other. ACKNOWLEDGE asks for a citation to research papers, while the CITATION.cff references a Zenodo software doi. I would recommend to list both (research paper and software citation) in ACKNOWLEDGE.rst and let README link to ACKNOWLEDGE.rst as I did in this PR, but I am open to suggestions for how to do this differently. 

As a longer term project it would also be nice to unify the file `doc/sphinx/acknowledgments.rst` with `ACKNOWLEDGE.rst` to remove duplication and the potential for conflicting advice. Currently www.pism.io does not contain any advice on what to cite when using PISM in a publication (or at least I couldnt find it), but I didnt want to touch any of that without asking first. One option to do that would be to create a link to `ACKNOWLEDGE.rst` from inside the sphinx documentation.

While working through this I found a few places in the README.rst that could be worded better or more clearly. Feel free to let me know in case you want them changed in a different way, or prefer the suggestions in a separate PR