### PR TITLE
Use time-averaged load in bed deformation models

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,14 @@ Changes since v2.1
   the code, model inputs and outputs, etc.
 - Add the configuration parameter `energy.model` (choices: `none`, `cold`, `enthalpy`);
   remove `energy.enabled` and `energy.temperature_based`.
+- All bed deformation models use the load averaged over the duration of the (usually long)
+  bed deformation time step (see `issue 525`_). This requires saving the time integral of
+  the load since the last bed deformation update (variable `bed_def_load_accumulator` and
+  the time of the last update `time_bed_deformation`) as a part of the model state and
+  reading them when re-starting the model. Rename `bed_deformation.lc.update_interval` to
+  `bed_deformation.update_interval` since now *all* bed deformation models use this
+  parameter. Add a new diagnostic variable: `bed_def_load`, the load used during the last
+  bed deformation update.
 
 Changes since v2.0
 ==================
@@ -985,6 +993,7 @@ Miscellaneous
 .. _issue 422: https://github.com/pism/pism/issues/422
 .. _issue 424: https://github.com/pism/pism/issues/424
 .. _issue 407: https://github.com/pism/pism/issues/407
+.. _issue 525: https://github.com/pism/pism/issues/525
 .. _ocean models: http://www.pism.io/docs/climate_forcing/ocean.html
 ..
    Local Variables:

--- a/doc/sphinx/manual/highlevelview/climate-inputs.rst
+++ b/doc/sphinx/manual/highlevelview/climate-inputs.rst
@@ -63,7 +63,7 @@ fields from a file or otherwise transfers them from a climate model.
 Regarding the base of the ice, the temperature of a layer of bedrock in contact with
 grounded ice is generally included in PISM's conservation of energy model; see subsections
 :ref:`sec-coords` and :ref:`sec-grid`. Also, as described in section
-:ref:`sec-beddef`, PISM can apply an optional bed deformation component approximating
+:ref:`sec-bed-def`, PISM can apply an optional bed deformation component approximating
 the movement of the Earth's crust and upper mantle in response to changing ice load. In
 these senses everything below the black dashed line in :numref:`fig-climate-inputs` is
 always "owned" by PISM.

--- a/doc/sphinx/manual/modeling-choices/computational/grid.rst
+++ b/doc/sphinx/manual/modeling-choices/computational/grid.rst
@@ -40,7 +40,7 @@ See :numref:`fig-grid-vertical-sigma`.
 Set :config:`grid.Mbz` to a number greater than one to use the bedrock thermal model. When
 a thermal bedrock layer is used, the depth of the layer is controlled by
 :config:`grid.Lbz`. Note that :config:`grid.Mbz` is unrelated to the bed deformation model
-(glacial isostasy model); see section :ref:`sec-beddef`.
+(glacial isostasy model); see section :ref:`sec-bed-def`.
 
 In the quadratically-spaced case the vertical spacing near the ice/bedrock interface is
 about :config:`grid.lambda` times finer than it would be with equal spacing for the same

--- a/doc/sphinx/manual/modeling-choices/subglacier/basal-strength.rst
+++ b/doc/sphinx/manual/modeling-choices/subglacier/basal-strength.rst
@@ -293,7 +293,7 @@ stands for the bed elevation. To explain these, we define `M = (\phimax - \phimi
      \phimax, & \bmax \le b(x,y).
    \end{cases}
 
-It is worth noting that an earth deformation model (see section :ref:`sec-beddef`) changes
+It is worth noting that an earth deformation model (see section :ref:`sec-bed-def`) changes
 `b(x,y)` (NetCDF variable :var:`topg`) used in :eq:`eq-phipiecewise`, so that a sequence
 of runs such as
 

--- a/doc/sphinx/manual/modeling-choices/subglacier/bed-deformation.rst
+++ b/doc/sphinx/manual/modeling-choices/subglacier/bed-deformation.rst
@@ -8,6 +8,18 @@ Earth deformation models
 The option :opt:`-bed_def` ``[iso, lc, given]`` (flag :config:`bed_deformation.model`) turns one
 of the three available bed deformation models.
 
+Bed deformation timescale is longer than that of ice flow; this makes it possible to use
+*asynchronous* coupling between bed deformation and ice dynamics sub-models of PISM. The
+parameter :config:`bed_deformation.update_interval` controls the coupling interval. Update
+interval of zero corresponds to synchronous coupling.
+
+When performing a step of a bed deformation model PISM uses the *average* of the load over
+the time interval since the last update. This is necessary to avoid temporal aliasing of
+"high-frequency" variations in the ice thickness due to the annual cycle of the surface
+mass balance when sampled at a lower frequency of bed deformation updates.
+
+Here only *grounded* ice contributes to the load on the bed. We ignore the contribution of
+floating shelves and the pressure of the column of water in the ocean.
 
 .. _sec-bed-def-iso:
 

--- a/doc/sphinx/manual/modeling-choices/subglacier/bed-deformation.rst
+++ b/doc/sphinx/manual/modeling-choices/subglacier/bed-deformation.rst
@@ -1,6 +1,6 @@
 .. include:: ../../../global.txt
 
-.. _sec-beddef:
+.. _sec-bed-def:
 
 Earth deformation models
 ------------------------

--- a/doc/sphinx/manual/practical-usage/time-stepping.rst
+++ b/doc/sphinx/manual/practical-usage/time-stepping.rst
@@ -88,7 +88,7 @@ step length.
 
 #. Atmosphere, surface process, ocean, and sea level forcing components.
 
-#. A bed deformation model (see :ref:`sec-bed-def-lc` and
+#. A bed deformation model (see :ref:`sec-bed-def` and
    :config:`bed_deformation.update_interval`).
 
 #. If :config:`geometry.front_retreat.use_cfl` is set, PISM adjusts time step lengths to

--- a/doc/sphinx/manual/practical-usage/time-stepping.rst
+++ b/doc/sphinx/manual/practical-usage/time-stepping.rst
@@ -88,8 +88,8 @@ step length.
 
 #. Atmosphere, surface process, ocean, and sea level forcing components.
 
-#. The Lingle-Clark bed deformation model (see :ref:`sec-bed-def-lc` and
-   :config:`bed_deformation.lc.update_interval`).
+#. A bed deformation model (see :ref:`sec-bed-def-lc` and
+   :config:`bed_deformation.update_interval`).
 
 #. If :config:`geometry.front_retreat.use_cfl` is set, PISM adjusts time step lengths to
    satisfy the CFL condition that uses the total front retreat rate coming from calving

--- a/doc/sphinx/manual/std-greenland/run-4.rst
+++ b/doc/sphinx/manual/std-greenland/run-4.rst
@@ -61,7 +61,7 @@ instead from a previously computed near-equilibrium result:
      -regrid_vars litho_temp,thk,enthalpy,tillwat,basal_melt_rate_grounded
 
 For more on regridding see section :ref:`sec-regridding`. Then we turn on the earth
-deformation model with option ``-bed_def lc``; see section :ref:`sec-beddef`. After
+deformation model with option ``-bed_def lc``; see section :ref:`sec-bed-def`. After
 that the atmosphere and surface (PDD) models are turned on and the files they need are
 identified:
 

--- a/src/earth/BedDef.cc
+++ b/src/earth/BedDef.cc
@@ -34,13 +34,12 @@ BedDef::BedDef(std::shared_ptr<const Grid> grid, const std::string &model_name)
     m_load(grid, "bed_def_load"),
     m_load_accumulator(grid, "bed_def_load_accumulator"),
     m_uplift(m_grid, "dbdt"),
+    m_t_last(time().current()),
     m_model_name(model_name)
 {
-
-  m_time_name = m_config->get_string("time.dimension_name") + "_bed_deformation";
-  m_t_last = time().current();
+  m_time_name       = m_config->get_string("time.dimension_name") + "_bed_deformation";
   m_update_interval = m_config->get_number("bed_deformation.update_interval", "seconds");
-  m_t_eps = m_config->get_number("time_stepping.resolution", "seconds");
+  m_t_eps           = m_config->get_number("time_stepping.resolution", "seconds");
 
   m_topg.metadata(0)
       .long_name("bedrock surface elevation")
@@ -114,16 +113,13 @@ void BedDef::init(const InputOptions &opts, const array::Scalar &ice_thickness,
   m_log->message(2, "* Initializing the %s bed deformation model...\n",
                  m_model_name.c_str());
 
+  m_t_last = time().current();
   if (opts.type == INIT_RESTART or opts.type == INIT_BOOTSTRAP) {
     File input_file(m_grid->com, opts.filename, io::PISM_NETCDF3, io::PISM_READONLY);
 
     if (input_file.variable_exists(m_time_name)) {
       input_file.read_variable(m_time_name, {0}, {1}, &m_t_last);
-    } else {
-      m_t_last = time().current();
     }
-  } else {
-    m_t_last = time().current();
   }
 
   {

--- a/src/earth/BedDef.cc
+++ b/src/earth/BedDef.cc
@@ -147,11 +147,11 @@ void BedDef::init(const InputOptions &opts, const array::Scalar &ice_thickness,
     }
 
     // process -regrid_file and -regrid_vars
-    regrid("bed deformation", m_topg);
-    regrid("bed deformation", m_load_accumulator);
+    regrid("bed deformation", m_topg, REGRID_WITHOUT_REGRID_VARS);
+    regrid("bed deformation", m_load_accumulator, REGRID_WITHOUT_REGRID_VARS);
     // uplift is not a part of the model state, but the user may want to take it from a -regrid_file
     // during bootstrapping
-    regrid("bed deformation", m_uplift);
+    regrid("bed deformation", m_uplift, REGRID_WITHOUT_REGRID_VARS);
 
     auto uplift_file = m_config->get_string("bed_deformation.bed_uplift_file");
     if (not uplift_file.empty()) {

--- a/src/earth/BedDef.cc
+++ b/src/earth/BedDef.cc
@@ -55,6 +55,7 @@ BedDef::BedDef(std::shared_ptr<const Grid> grid, const std::string &model_name)
   m_load.metadata(0)
     .long_name("load on the bed expressed as ice-equivalent thickness")
     .units("m");
+  m_load.set(0.0);
 
   m_load_accumulator.metadata(0)
     .long_name("accumulated load on the bed expressed as a time integral of ice-equivalent thickness")
@@ -99,7 +100,9 @@ void BedDef::write_model_state_impl(const File &output) const {
 
 DiagnosticList BedDef::diagnostics_impl() const {
   DiagnosticList result;
-  result = { { "dbdt", Diagnostic::wrap(m_uplift) }, { "topg", Diagnostic::wrap(m_topg) } };
+  result = { { "dbdt", Diagnostic::wrap(m_uplift) },
+             { "topg", Diagnostic::wrap(m_topg) },
+             { "bed_def_load", Diagnostic::wrap(m_load) } };
 
   return result;
 }

--- a/src/earth/BedDef.cc
+++ b/src/earth/BedDef.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2022, 2023, 2024 Constantine Khroulev
+// Copyright (C) 2010--2024 PISM Authors
 //
 // This file is part of PISM.
 //
@@ -16,13 +16,15 @@
 // along with PISM; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
+#include <string>
+
 #include "pism/earth/BedDef.hh"
 #include "pism/util/ConfigInterface.hh"
 #include "pism/util/Context.hh"
 #include "pism/util/Grid.hh"
 #include "pism/util/MaxTimestep.hh"
 #include "pism/util/Time.hh"
-#include <string>
+
 
 namespace pism {
 namespace bed {

--- a/src/earth/BedDef.hh
+++ b/src/earth/BedDef.hh
@@ -30,10 +30,8 @@ namespace bed {
 double compute_load(double bed, double ice_thickness, double sea_level,
                     double ice_density, double ocean_density);
 
-void compute_load(const array::Scalar &bed_elevation,
-                  const array::Scalar &ice_thickness,
-                  const array::Scalar &sea_level_elevation,
-                  array::Scalar &result);
+void accumulate_load(const array::Scalar &bed_elevation, const array::Scalar &ice_thickness,
+                     const array::Scalar &sea_level_elevation, double C, array::Scalar &result);
 
 //! PISM bed deformation model (base class).
 class BedDef : public Component {

--- a/src/earth/Given.cc
+++ b/src/earth/Given.cc
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020, 2021, 2022, 2023 PISM Authors
+/* Copyright (C) 2020, 2021, 2022, 2023, 2024 PISM Authors
  *
  * This file is part of PISM.
  *
@@ -24,7 +24,7 @@ namespace pism {
 namespace bed {
 
 Given::Given(std::shared_ptr<const Grid> grid)
-  : BedDef(grid),
+  : BedDef(grid, "'prescribed topography change history'"),
     m_topg_reference(grid, "topg") {
 
   m_topg_reference.metadata(0)
@@ -51,42 +51,35 @@ Given::Given(std::shared_ptr<const Grid> grid)
   }
 }
 
-void Given::init_impl(const InputOptions &opts, const array::Scalar &ice_thickness,
-                      const array::Scalar &sea_level_elevation) {
-  (void) ice_thickness;
-  (void) sea_level_elevation;
-
-  m_log->message(2,
-                 "* Initializing the bed model using a given topography change history...\n");
-
-  BedDef::init_impl(opts, ice_thickness, sea_level_elevation);
-
+void Given::init_impl(const InputOptions & /*opts*/, const array::Scalar & /*ice_thickness*/,
+                      const array::Scalar & /*sea_level_elevation*/) {
   {
     auto reference_filename = m_config->get_string("bed_deformation.given.reference_file");
     m_topg_reference.regrid(reference_filename, io::Default::Nil()); // fails if not found!
   }
 
   {
-    auto filename = m_config->get_string("bed_deformation.given.file");
-    m_topg_delta->init(filename, false);
+    auto filename   = m_config->get_string("bed_deformation.given.file");
+    bool periodic_p = false;
+    m_topg_delta->init(filename, periodic_p);
   }
 }
 
-void Given::update_impl(const array::Scalar &ice_thickness,
-                        const array::Scalar &sea_level_elevation,
-                        double t, double dt) {
-  (void) ice_thickness;
-  (void) sea_level_elevation;
+void Given::bootstrap_impl(const array::Scalar & /*bed_elevation*/,
+                           const array::Scalar & /*bed_uplift*/,
+                           const array::Scalar & /*ice_thickness*/,
+                           const array::Scalar & /*sea_level_elevation*/) {
+  // empty
+}
 
+void Given::update_impl(const array::Scalar & /*load*/, double t, double dt) {
   m_topg_delta->update(t, dt);
   m_topg_delta->average(t, dt);
 
-  m_topg_last.copy_from(m_topg);
+  m_topg_reference.add(1.0, *m_topg_delta, m_topg);
 
-  m_topg.copy_from(m_topg_reference);
-  m_topg.add(1.0, *m_topg_delta);
-
-  compute_uplift(m_topg, m_topg_last, dt, m_uplift);
+  // mark m_topg as "modified"
+  m_topg.inc_state_counter();
 }
 
 } // end of namespace bed

--- a/src/earth/Given.hh
+++ b/src/earth/Given.hh
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020, 2021, 2022, 2023 PISM Authors
+/* Copyright (C) 2020, 2021, 2022, 2023, 2024 PISM Authors
  *
  * This file is part of PISM.
  *
@@ -36,9 +36,12 @@ protected:
   void init_impl(const InputOptions &opts, const array::Scalar &ice_thickness,
                  const array::Scalar &sea_level_elevation);
 
-  void update_impl(const array::Scalar &ice_thickness,
-                   const array::Scalar &sea_level_elevation,
-                   double t, double dt);
+  void bootstrap_impl(const array::Scalar &bed_elevation,
+                      const array::Scalar &bed_uplift,
+                      const array::Scalar &ice_thickness,
+                      const array::Scalar &sea_level_elevation);
+
+  void update_impl(const array::Scalar &load, double t, double dt);
 
   array::Scalar m_topg_reference;
 

--- a/src/earth/LingleClark.cc
+++ b/src/earth/LingleClark.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2010, 2011, 2012, 2013, 2014, 2015, 2017, 2018, 2019, 2020, 2021, 2023, 2024 Constantine Khroulev
+// Copyright (C) 2010--2024 PISM Authors
 //
 // This file is part of PISM.
 //
@@ -19,12 +19,9 @@
 #include "pism/earth/LingleClark.hh"
 
 #include "pism/util/io/File.hh"
-#include "pism/util/Time.hh"
 #include "pism/util/Grid.hh"
 #include "pism/util/ConfigInterface.hh"
 #include "pism/util/error_handling.hh"
-#include "pism/util/Vars.hh"
-#include "pism/util/MaxTimestep.hh"
 #include "pism/util/pism_utilities.hh"
 #include "pism/util/fftw_utilities.hh"
 #include "pism/earth/LingleClarkSerial.hh"
@@ -35,22 +32,10 @@ namespace pism {
 namespace bed {
 
 LingleClark::LingleClark(std::shared_ptr<const Grid> grid)
-  : BedDef(grid),
+  : BedDef(grid, "Lingle-Clark"),
     m_total_displacement(m_grid, "bed_displacement"),
     m_relief(m_grid, "bed_relief"),
-    m_load_thickness(grid, "load_thickness"),
     m_elastic_displacement(grid, "elastic_bed_displacement") {
-
-  m_time_name = m_config->get_string("time.dimension_name") + "_lingle_clark";
-  m_t_last = time().current();
-  m_update_interval = m_config->get_number("bed_deformation.lc.update_interval", "seconds");
-  m_t_eps = m_config->get_number("time_stepping.resolution", "seconds");
-
-  if (m_update_interval < 1.0) {
-    throw RuntimeError::formatted(PISM_ERROR_LOCATION,
-                                  "invalid bed_deformation.lc.update_interval = %f seconds",
-                                  m_update_interval);
-  }
 
   // A work vector. This storage is used to put thickness change on rank 0 and to get the plate
   // displacement change back.
@@ -118,7 +103,8 @@ LingleClark::LingleClark(std::shared_ptr<const Grid> grid)
 }
 
 LingleClark::~LingleClark() {
-  // empty
+  // empty, but implemented here instead of using "= default" in the header to be able to
+  // use the forward declaration of LingleClarkSerial in LingleClark.hh
 }
 
 /*!
@@ -134,19 +120,14 @@ void LingleClark::bootstrap_impl(const array::Scalar &bed_elevation,
                                  const array::Scalar &bed_uplift,
                                  const array::Scalar &ice_thickness,
                                  const array::Scalar &sea_level_elevation) {
-  m_t_last = time().current();
+  compute_load(bed_elevation, ice_thickness, sea_level_elevation, m_load);
 
-  m_topg_last.copy_from(bed_elevation);
-
-  compute_load(bed_elevation, ice_thickness, sea_level_elevation,
-               m_load_thickness);
-
-  std::shared_ptr<petsc::Vec> thickness0 = m_load_thickness.allocate_proc0_copy();
+  std::shared_ptr<petsc::Vec> thickness0 = m_load.allocate_proc0_copy();
 
   // initialize the plate displacement
   {
     bed_uplift.put_on_proc0(*m_work0);
-    m_load_thickness.put_on_proc0(*thickness0);
+    m_load.put_on_proc0(*thickness0);
 
     ParallelSection rank0(m_grid->com);
     try {
@@ -226,25 +207,6 @@ std::shared_ptr<array::Scalar> LingleClark::elastic_load_response_matrix() const
  */
 void LingleClark::init_impl(const InputOptions &opts, const array::Scalar &ice_thickness,
                             const array::Scalar &sea_level_elevation) {
-  m_log->message(2, "* Initializing the Lingle-Clark bed deformation model...\n");
-
-  if (opts.type == INIT_RESTART or opts.type == INIT_BOOTSTRAP) {
-    File input_file(m_grid->com, opts.filename, io::PISM_NETCDF3, io::PISM_READONLY);
-
-    if (input_file.variable_exists(m_time_name)) {
-      input_file.read_variable(m_time_name, {0}, {1}, &m_t_last);
-    } else {
-      m_t_last = time().current();
-    }
-  } else {
-    m_t_last = time().current();
-  }
-
-  // Initialize bed topography and uplift maps.
-  BedDef::init_impl(opts, ice_thickness, sea_level_elevation);
-
-  m_topg_last.copy_from(m_topg);
-
   if (opts.type == INIT_RESTART) {
     // Set viscous displacement by reading from the input file.
     m_viscous_displacement->read(opts.filename, opts.record);
@@ -263,7 +225,7 @@ void LingleClark::init_impl(const InputOptions &opts, const array::Scalar &ice_t
          m_elastic_displacement, REGRID_WITHOUT_REGRID_VARS);
 
   compute_load(m_topg, ice_thickness, sea_level_elevation,
-               m_load_thickness);
+               m_load);
 
   // Now that viscous displacement and elastic displacement are finally initialized,
   // put them on rank 0 and initialize the serial model itself.
@@ -293,29 +255,6 @@ void LingleClark::init_impl(const InputOptions &opts, const array::Scalar &ice_t
   m_topg.add(-1.0, m_total_displacement, m_relief);
 }
 
-MaxTimestep LingleClark::max_timestep_impl(double t) const {
-
-  if (t < m_t_last) {
-    throw RuntimeError::formatted(PISM_ERROR_LOCATION,
-                                  "time %f is less than the previous time %f",
-                                  t, m_t_last);
-  }
-
-  // Find the smallest time of the form m_t_last + k * m_update_interval that is greater
-  // than t
-  double k = ceil((t - m_t_last) / m_update_interval);
-
-  double
-    t_next = m_t_last + k * m_update_interval,
-    dt_max = t_next - t;
-
-  if (dt_max < m_t_eps) {
-    dt_max = m_update_interval;
-  }
-
-  return MaxTimestep(dt_max, "bed_def lc");
-}
-
 /*!
  * Get total bed displacement on the PISM grid.
  */
@@ -335,14 +274,10 @@ const array::Scalar& LingleClark::relief() const {
   return m_relief;
 }
 
-void LingleClark::step(const array::Scalar &ice_thickness,
-                       const array::Scalar &sea_level_elevation,
+void LingleClark::step(const array::Scalar &load_thickness,
                        double dt) {
 
-  compute_load(m_topg, ice_thickness, sea_level_elevation,
-               m_load_thickness);
-
-  m_load_thickness.put_on_proc0(*m_work0);
+  load_thickness.put_on_proc0(*m_work0);
 
   ParallelSection rank0(m_grid->com);
   try {
@@ -372,50 +307,21 @@ void LingleClark::step(const array::Scalar &ice_thickness,
   m_total_displacement.get_from_proc0(*m_work0);
 
   // Update bed elevation using bed displacement and relief.
-  {
-    m_total_displacement.add(1.0, m_relief, m_topg);
-    // Increment the topg state counter. SIAFD relies on this!
-    m_topg.inc_state_counter();
-  }
-
-  //! Finally, we need to update bed uplift and topg_last.
-  compute_uplift(m_topg, m_topg_last, dt, m_uplift);
-  m_topg_last.copy_from(m_topg);
+  m_total_displacement.add(1.0, m_relief, m_topg);
 }
 
 //! Update the Lingle-Clark bed deformation model.
-void LingleClark::update_impl(const array::Scalar &ice_thickness,
-                              const array::Scalar &sea_level_elevation,
-                              double t, double dt) {
-
-  double
-    t_next  = m_t_last + m_update_interval,
-    t_final = t + dt;
-
-  if (t_final < m_t_last) {
-    throw RuntimeError(PISM_ERROR_LOCATION, "cannot go back in time");
-  }
-
-  if (std::abs(t_next - t_final) < m_t_eps) { // reached the next update time
-    double dt_beddef = t_final - m_t_last;
-    step(ice_thickness, sea_level_elevation, dt_beddef);
-    m_t_last = t_final;
-  }
+void LingleClark::update_impl(const array::Scalar &load, double /*t*/, double dt) {
+  step(load, dt);
+  // mark m_topg as "modified"
+  m_topg.inc_state_counter();
 }
 
 void LingleClark::define_model_state_impl(const File &output) const {
   BedDef::define_model_state_impl(output);
+
   m_viscous_displacement->define(output, io::PISM_DOUBLE);
   m_elastic_displacement.define(output, io::PISM_DOUBLE);
-
-  if (not output.variable_exists(m_time_name)) {
-    output.define_variable(m_time_name, io::PISM_DOUBLE, {});
-
-    output.write_attribute(m_time_name, "long_name",
-                        "time of the last update of the Lingle-Clark bed deformation model");
-    output.write_attribute(m_time_name, "calendar", time().calendar());
-    output.write_attribute(m_time_name, "units", time().units_string());
-  }
 }
 
 void LingleClark::write_model_state_impl(const File &output) const {
@@ -423,8 +329,6 @@ void LingleClark::write_model_state_impl(const File &output) const {
 
   m_viscous_displacement->write(output);
   m_elastic_displacement.write(output);
-
-  output.write_variable(m_time_name, {0}, {1}, &m_t_last);
 }
 
 DiagnosticList LingleClark::diagnostics_impl() const {

--- a/src/earth/LingleClark.hh
+++ b/src/earth/LingleClark.hh
@@ -1,4 +1,4 @@
-/* Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2023 PISM Authors
+/* Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2023, 2024 PISM Authors
  *
  * This file is part of PISM.
  *
@@ -17,8 +17,8 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#ifndef _PBLINGLECLARK_H_
-#define _PBLINGLECLARK_H_
+#ifndef PISM_LINGLE_CLARK_H
+#define PISM_LINGLE_CLARK_H
 
 #include <memory>               // std::unique_ptr
 
@@ -43,8 +43,7 @@ public:
 
   const array::Scalar& relief() const;
 
-  void step(const array::Scalar &ice_thickness,
-            const array::Scalar &sea_level_elevation,
+  void step(const array::Scalar &load_thickness,
             double dt);
 
   std::shared_ptr<array::Scalar> elastic_load_response_matrix() const;
@@ -54,16 +53,13 @@ protected:
 
   DiagnosticList diagnostics_impl() const;
 
-  MaxTimestep max_timestep_impl(double t) const;
   void init_impl(const InputOptions &opts, const array::Scalar &ice_thickness,
                  const array::Scalar &sea_level_elevation);
   void bootstrap_impl(const array::Scalar &bed_elevation,
                       const array::Scalar &bed_uplift,
                       const array::Scalar &ice_thickness,
                       const array::Scalar &sea_level_elevation);
-  void update_impl(const array::Scalar &ice_thickness,
-                   const array::Scalar &sea_level_elevation,
-                   double t, double dt);
+  void update_impl(const array::Scalar &load, double t, double dt);
 
   //! Total (viscous and elastic) bed displacement.
   array::Scalar m_total_displacement;
@@ -74,9 +70,6 @@ protected:
 
   //! Bed relief relative to the bed displacement.
   array::Scalar m_relief;
-
-  //! Ice-equivalent load thickness.
-  array::Scalar m_load_thickness;
 
   //! Serial viscoelastic bed deformation model.
   std::unique_ptr<LingleClarkSerial> m_serial_model;
@@ -93,18 +86,9 @@ protected:
   array::Scalar m_elastic_displacement;
   //! rank 0 storage for the elastic displacement
   std::shared_ptr<petsc::Vec> m_elastic_displacement0;
-
-  //! time of the last bed deformation update
-  double m_t_last;
-  //! Update interval in seconds
-  double m_update_interval;
-  //! Temporal resolution to use when checking whether it's time to update
-  double m_t_eps;
-  //! Name of the variable used to store the last update time.
-  std::string m_time_name;
 };
 
 } // end of namespace bed
 } // end of namespace pism
 
-#endif /* _PBLINGLECLARK_H_ */
+#endif /* PISM_LINGLE_CLARK_H */

--- a/src/earth/Null.cc
+++ b/src/earth/Null.cc
@@ -1,4 +1,4 @@
-/* Copyright (C) 2015, 2016, 2017, 2018, 2023 PISM Authors
+/* Copyright (C) 2015, 2016, 2017, 2018, 2023, 2024 PISM Authors
  *
  * This file is part of PISM.
  *
@@ -25,33 +25,29 @@ namespace pism {
 namespace bed {
 
 Null::Null(std::shared_ptr<const Grid> g)
-  : BedDef(g) {
+  : BedDef(g, "dummy (no-op)") {
   // empty
 }
 
-void Null::init_impl(const InputOptions &opts, const array::Scalar &ice_thickness,
-                     const array::Scalar &sea_level_elevation) {
-  m_log->message(2,
-             "* Initializing the dummy (no-op) bed deformation model...\n");
-
-  BedDef::init_impl(opts, ice_thickness, sea_level_elevation);
-
+void Null::init_impl(const InputOptions & /*opts*/, const array::Scalar & /*ice_thickness*/,
+                     const array::Scalar & /*sea_level_elevation*/) {
   m_uplift.set(0.0);
 }
 
-MaxTimestep Null::max_timestep_impl(double t) const {
-  (void) t;
-  return MaxTimestep("bed_def none");
+void Null::bootstrap_impl(const array::Scalar & /*bed_elevation*/,
+                           const array::Scalar & /*bed_uplift*/,
+                           const array::Scalar & /*ice_thickness*/,
+                           const array::Scalar & /*sea_level_elevation*/) {
+  // empty
 }
 
-void Null::update_impl(const array::Scalar &ice_thickness,
-                       const array::Scalar &sea_level_elevation,
-                       double t, double dt) {
-  (void) ice_thickness;
-  (void) sea_level_elevation;
-  (void) t;
-  (void) dt;
-  // This model does not update bed topography or bed uplift.
+void Null::update_impl(const array::Scalar &/*load*/,
+                       double /*t*/, double /*dt*/) {
+  // This model does not update bed topography
+}
+
+MaxTimestep Null::max_timestep_impl(double /*t*/) const {
+  return {};
 }
 
 } // end of namespace bed

--- a/src/earth/PointwiseIsostasy.cc
+++ b/src/earth/PointwiseIsostasy.cc
@@ -31,7 +31,8 @@ PointwiseIsostasy::PointwiseIsostasy(std::shared_ptr<const Grid> grid)
 void PointwiseIsostasy::init_impl(const InputOptions &/*opts*/, const array::Scalar &ice_thickness,
                                   const array::Scalar &sea_level_elevation) {
   // store the initial load
-  compute_load(m_topg, ice_thickness, sea_level_elevation, m_load_last);
+  m_load_last.set(0.0);
+  accumulate_load(m_topg, ice_thickness, sea_level_elevation, 1.0, m_load_last);
 }
 
 
@@ -40,7 +41,8 @@ void PointwiseIsostasy::bootstrap_impl(const array::Scalar &bed_elevation,
                                        const array::Scalar &ice_thickness,
                                        const array::Scalar &sea_level_elevation) {
   // store initial load and bed elevation
-  compute_load(bed_elevation, ice_thickness, sea_level_elevation, m_load_last);
+  m_load_last.set(0.0);
+  accumulate_load(bed_elevation, ice_thickness, sea_level_elevation, 1.0, m_load_last);
   m_topg_last.copy_from(bed_elevation);
 }
 

--- a/src/pism_config.cdl
+++ b/src/pism_config.cdl
@@ -542,12 +542,6 @@ netcdf pism_config {
     pism_config:bed_deformation.lc.grid_size_factor_type = "integer";
     pism_config:bed_deformation.lc.grid_size_factor_units = "count";
 
-    pism_config:bed_deformation.update_interval = 10.0;
-    pism_config:bed_deformation.update_interval_doc = "Interval between updates of bed deformation models";
-    pism_config:bed_deformation.update_interval_type = "number";
-    pism_config:bed_deformation.update_interval_units = "365days";
-    pism_config:bed_deformation.update_interval_valid_min = 0.0;
-
     pism_config:bed_deformation.lithosphere_flexural_rigidity = 5.0e24;
     pism_config:bed_deformation.lithosphere_flexural_rigidity_doc = "lithosphere flexural rigidity used by the bed deformation model. See :cite:`LingleClark`, :cite:`BLKfastearth`";
     pism_config:bed_deformation.lithosphere_flexural_rigidity_type = "number";
@@ -568,6 +562,12 @@ netcdf pism_config {
     pism_config:bed_deformation.model_doc = "Selects a bed deformation model to use. ``iso`` is point-wise isostasy, ``lc`` is the Lingle-Clark model (see :cite:`LingleClark`, requires FFTW_), ``given`` uses prescribed bed topography changes read from a file.";
     pism_config:bed_deformation.model_option = "bed_def";
     pism_config:bed_deformation.model_type = "keyword";
+
+    pism_config:bed_deformation.update_interval = 10.0;
+    pism_config:bed_deformation.update_interval_doc = "Interval between updates of bed deformation models";
+    pism_config:bed_deformation.update_interval_type = "number";
+    pism_config:bed_deformation.update_interval_units = "365days";
+    pism_config:bed_deformation.update_interval_valid_min = 0.0;
 
     pism_config:bootstrapping.defaults.bed = 1.0;
     pism_config:bootstrapping.defaults.bed_doc = "bed elevation value to use if :var:`topg` (``bedrock_altitude``) variable is absent in bootstrapping file";

--- a/src/pism_config.cdl
+++ b/src/pism_config.cdl
@@ -542,10 +542,11 @@ netcdf pism_config {
     pism_config:bed_deformation.lc.grid_size_factor_type = "integer";
     pism_config:bed_deformation.lc.grid_size_factor_units = "count";
 
-    pism_config:bed_deformation.lc.update_interval = 10.0;
-    pism_config:bed_deformation.lc.update_interval_doc = "Interval between updates of the Lingle-Clark model";
-    pism_config:bed_deformation.lc.update_interval_type = "number";
-    pism_config:bed_deformation.lc.update_interval_units = "365days";
+    pism_config:bed_deformation.update_interval = 10.0;
+    pism_config:bed_deformation.update_interval_doc = "Interval between updates of bed deformation models";
+    pism_config:bed_deformation.update_interval_type = "number";
+    pism_config:bed_deformation.update_interval_units = "365days";
+    pism_config:bed_deformation.update_interval_valid_min = 0.0;
 
     pism_config:bed_deformation.lithosphere_flexural_rigidity = 5.0e24;
     pism_config:bed_deformation.lithosphere_flexural_rigidity_doc = "lithosphere flexural rigidity used by the bed deformation model. See :cite:`LingleClark`, :cite:`BLKfastearth`";

--- a/test/regression/CMakeLists.txt
+++ b/test/regression/CMakeLists.txt
@@ -147,6 +147,8 @@ if(Pism_BUILD_PYTHON_BINDINGS)
 
         pism_python_test (Python:sia_forward.py test_33.sh)
 
+        pism_python_test (bed_deformation:load_averaging beddef_load_averaging.sh)
+
 # Inversion regression tests.
 
         execute_process (COMMAND ${PYTHON_EXECUTABLE} -c "import siple"

--- a/test/regression/beddef_iso.py
+++ b/test/regression/beddef_iso.py
@@ -7,6 +7,8 @@ import PISM
 
 ctx  = PISM.Context().ctx
 
+ctx.config().set_number("bed_deformation.update_interval", 0.0)
+
 def exact(ice_thickness_change):
     "Exact deflection corresponding to a given thickness change."
 

--- a/test/regression/beddef_lc_elastic.py
+++ b/test/regression/beddef_lc_elastic.py
@@ -87,7 +87,7 @@ class LingleClarkElastic(TestCase):
 
         # dt of zero disables the viscous part of the model, so all we get is the elastic
         # response
-        bed_model.step(geometry.ice_thickness, geometry.sea_level_elevation, 0)
+        bed_model.step(geometry.ice_thickness, 0)
 
         return (geometry.ice_thickness.to_numpy(),
                 bed_model.total_displacement().to_numpy(),

--- a/test/regression/beddef_lc_restart.py
+++ b/test/regression/beddef_lc_restart.py
@@ -73,7 +73,7 @@ def run(dt, restart=False):
     add_disc_load(geometry.ice_thickness, disc_radius, disc_thickness)
 
     # do 1 step
-    model.step(geometry.ice_thickness, geometry.sea_level_elevation, dt)
+    model.step(geometry.ice_thickness, dt)
 
     if restart:
         # save the model state
@@ -96,7 +96,7 @@ def run(dt, restart=False):
             os.remove(filename)
 
     # do 1 more step
-    model.step(geometry.ice_thickness, geometry.sea_level_elevation, dt)
+    model.step(geometry.ice_thickness, dt)
 
     return model
 

--- a/test/regression/beddef_lc_viscous.py
+++ b/test/regression/beddef_lc_viscous.py
@@ -92,7 +92,7 @@ def modeled_time_dependent(dics_radius, disc_thickness, t_end, L, Nx, dt):
         if t + dt > t_end:
             dt = t_end - t
 
-        bed_model.step(ice_thickness, sea_level, dt)
+        bed_model.step(ice_thickness, dt)
 
         t += dt
         log.message(2, ".")

--- a/test/regression/beddef_load_averaging.sh
+++ b/test/regression/beddef_load_averaging.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+
+# Testing temporal averaging of the load used by bed deformation models.
+
+PISM_PATH=$1
+MPIEXEC=$2
+PISM_SOURCE_DIR=$3
+
+if [ $# -ge 4 ] && [ "$4" == "-python" ]
+then
+  PYTHONEXEC=$5
+  export PYTHONPATH=${PISM_PATH}/site-packages:${PYTHONPATH}
+else
+  exit 1
+fi
+
+pism="$PISM_PATH/pismr"
+
+# create a temporary directory and set up automatic cleanup
+temp_dir=$(mktemp -d --tmpdir pism-test-XXXX)
+trap 'rm -rf "$temp_dir"' EXIT
+cd $temp_dir
+
+# Make sure PISM can find the configuration file
+echo "
+-config ${PISM_PATH}/pism_config.nc
+" > .petscrc
+
+set -e
+set -u
+set -x
+
+${PYTHONEXEC} <<EOF
+import PISM
+import PISM.testing as pt
+import numpy as np
+
+ctx = PISM.Context().ctx
+
+ice_density = ctx.config().get_number("constants.ice.density")
+
+Lx = 500e3
+M = 5
+grid = PISM.Grid.Shallow(ctx, Lx, Lx, 0, 0, M, M, PISM.CELL_CENTER, PISM.NOT_PERIODIC)
+
+def forcing(values, filename):
+    days_per_year = 360
+    times = np.array([2, 6, 10, 14]) / 16 * days_per_year
+    time_bounds = np.array([0, 4, 8, 12, 16]) / 16 * days_per_year
+
+    pt.create_forcing(grid,
+                      filename,
+                      "delta_P",
+                      "kg / (m^2 360 day)",
+                      values,
+                      time_units="days since 1-1-1",
+                      times=times,
+                      time_bounds=time_bounds)
+
+
+def input_data(thickness, filename):
+    bed = PISM.Scalar(grid, "bed")
+    # well above sea level to avoid "flooding" a part of it and losing SMB (it is not applied
+    # to ice free ocean)
+    bed.set(1000.0)
+    bed.metadata(0).standard_name("bedrock_altitude").units("m")
+
+    thk = PISM.Scalar(grid, "thk")
+    thk.set(thickness)
+    thk.metadata(0).standard_name("land_ice_thickness").units("m")
+
+    try:
+        f = PISM.util.prepare_output(filename, calendar="360_day")
+        thk.write(f)
+        bed.write(f)
+    finally:
+        f.close()
+
+forcing(np.array([10.0, -10, -10.0, 10.0]) * ice_density, "dP_PMMP.nc")
+forcing(np.array([-10, -10, 10, 10]) * ice_density, "dP_MMPP.nc")
+forcing(np.array([0, 0, 0, 0]) * ice_density, "dP_0.nc")
+
+input_data(10, "H-10.nc")
+input_data(12.5, "H-12.5.nc")
+EOF
+
+
+common_options="
+-atmosphere uniform,delta_P
+-atmosphere.delta_P.periodic
+-atmosphere.uniform.precipitation 0
+-bed_def lc
+-bed_deformation.update_interval 360days
+-bootstrap
+-calendar 360_day
+-energy none
+-max_dt 90days
+-stress_balance none
+-surface simple
+-ys 1-1-1
+"
+
+extra="
+-extra_times 720days
+-extra_vars topg
+"
+
+# 1. Bootstrap from the file with H=10m and run for N years with SMB=[10, -10, -10, 10]
+#
+# 2.1. Bootstrap from the file with H=10m. Run for 0s to get viscous and elastic bed
+#      displacements corresponding to equilibrium with the ice thickness H=10m. Save to
+#      H-10-full.nc
+#
+#      This step is needed so that in 2.2 below the bed deformation model is in
+#      equilibrium with H=10m *at the beginning of the run*. Otherwise it would be in
+#      equilibrium with H=12.5m and the load of 10m would result in some uplift.
+#
+# 2.2. Bootstrap from H-12.5.nc and regrid elastic and viscous displacement from H-10-full.nc
+#      and run for N years with SMB=[-10, 10, 10, -10]
+#
+# 3. Bootstrap from the file with H=10m. Run for N years with SMB=0.
+#
+# In the first two cases the SMB over 1 year is zero and ice thickness oscillates between
+# 7.5 m and 12.5 m with the average of 10m. The average load is the same, but the load at
+# the end of the year is different.
+
+# Run for 2 years. Here we update bed elevation every year, so this is enough.
+N=2
+run_length=$(( N * 360 ))
+
+# 1. Bootstrap from the file with H=10m and run for N years with SMB=[10, -10, -10, 10]
+#
+${pism} \
+   ${common_options} \
+   -atmosphere.delta_P.file dP_PMMP.nc \
+   ${extra} -extra_file ex_PMMP.nc \
+   -i H-10.nc \
+   -time.run_length ${run_length}days \
+   -o_size none \
+   ""
+
+# 2.1. Bootstrap from the file with H=10m. Run for 0s to get viscous and elastic bed
+#      displacements corresponding to equilibrium with the ice thickness H=10m. Save to
+#      H-10-full.nc
+#
+${pism} \
+   ${common_options} \
+   -atmosphere.delta_P.file dP_PMMP.nc \
+   -i H-10.nc \
+   -o H-10-full.nc \
+   -time.run_length 0 \
+   ""
+
+# 2.2. Bootstrap from H-12.5.nc, then regrid elastic and viscous displacement from
+#      H-10-full.nc and run for N years with SMB=[-10, -10, 10, 10]
+#
+${pism} \
+   ${common_options} \
+   -atmosphere.delta_P.file dP_MMPP.nc \
+   ${extra} -extra_file ex_MMPP.nc \
+   -i H-12.5.nc \
+   -regrid_file H-10-full.nc \
+   -regrid_vars viscous_bed_displacement,elastic_bed_displacement \
+   -time.run_length ${run_length}days \
+   -o_size none \
+   ""
+
+# 3. Bootstrap from the file with H=10m. Run for N years with SMB=0.
+#
+${pism} \
+   ${common_options} \
+   -atmosphere.delta_P.file dP_0.nc \
+   ${extra} -extra_file ex_0.nc \
+   -i H-10.nc \
+   -time.run_length ${run_length}days \
+   -o_size none \
+   ""
+
+# Compare results
+$PISM_PATH/nccmp.py -v topg ex_0.nc ex_PMMP.nc && $PISM_PATH/nccmp.py -v topg ex_0.nc ex_MMPP.nc

--- a/test/regression/temp_continuity.py
+++ b/test/regression/temp_continuity.py
@@ -15,7 +15,7 @@ def run(cmd):
 pism_path = sys.argv[1]
 mpiexec = sys.argv[2]
 
-cmd = "{path}/pismr -test F -y 10 -verbose 1 -o_size small -no_report -o in-temp-continuity.nc".format(path=pism_path)
+cmd = f"{pism_path}/pismr -test F -y 10 -verbose 1 -o_size small -no_report -o in-temp-continuity.nc"
 
 run(cmd)
 


### PR DESCRIPTION
Implement temporal averaging of the load in bed deformation models. See #525.

**Checklist**

- [x] updated documentation
- [x] updated [`CHANGES.rst`](CHANGES.rst)
- [x] added a regression test
