### PR TITLE
Fix Spack build

### DIFF
--- a/doc/sphinx/installation/spack.rst
+++ b/doc/sphinx/installation/spack.rst
@@ -15,13 +15,7 @@ documentation`_) and then run
 
    spack install pism
 
-This will install PISM and all its prerequisites, including PETSc. The default PETSc
-configuration in its Spack package includes many optional features not used by PISM. You
-may want to disable these; to do this, use this command instead:
-
-.. code-block:: bash
-
-   spack install pism ^petsc~metis~hdf5~hypre~superlu-dist
+This will install PISM and all its prerequisites, including PETSc.
 
 .. note::
 

--- a/doc/sphinx/installation/spack.rst
+++ b/doc/sphinx/installation/spack.rst
@@ -8,14 +8,20 @@ Installing PISM using Spack
 On supercomputers, Linux, and macOS PISM can be installed using the Spack_ package
 manager.
 
-Installing `PISM <https://packages.spack.io/package.html?name=pism>`_ using this method is easy: install Spack itself (see `Spack
-documentation`_) and then run
+Installing `PISM <https://packages.spack.io/package.html?name=pism>`_ using this method
+is easy: install Spack itself (see `Spack documentation`_) and then run
 
 .. code-block:: bash
 
    spack install pism
 
-This will install PISM and all its prerequisites, including PETSc.
+This will install PISM and all its prerequisites, including PETSc. The default PETSc
+configuration in its Spack package includes many optional features not used by PISM. You
+may want to disable these; to do this, use this command instead:
+
+.. code-block:: bash
+
+   spack install pism ^petsc~metis~hdf5~hypre~superlu-dist
 
 .. note::
 

--- a/doc/sphinx/installation/spack.rst
+++ b/doc/sphinx/installation/spack.rst
@@ -8,7 +8,7 @@ Installing PISM using Spack
 On supercomputers, Linux, and macOS PISM can be installed using the Spack_ package
 manager.
 
-Installing PISM using this method is easy: install Spack itself (see `Spack
+Installing `PISM <https://packages.spack.io/package.html?name=pism>`_ using this method is easy: install Spack itself (see `Spack
 documentation`_) and then run
 
 .. code-block:: bash


### PR DESCRIPTION
This PR fixes the docs related to the Spack build of PISM and relates to the following Spack PR: https://github.com/spack/spack/pull/47921

**Note:** PISM v2.1 builds using Spack and requires PETSc <= 3.20 because of deprecation of `DMDASNESFunction` and `DMDASNESJacobian` for SNES (see https://petsc.org/release/changes/321/).