### PR TITLE
Use pyproject.toml to build PISM

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,11 @@ Changes since v2.3.2
 - Scope the Clang-only `-fstandalone-debug` flag to C++ compilations only, so a
   mixed C/C++ toolchain (e.g., conda's GCC for C with Clang for C++) no longer
   fails to build C sources such as `calcalcs.c`.
+- Usage: To ensure `pism_config.nc` gets installed properly, one needs to::
+    
+    CMAKE_BUILD_PARALLEL_LEVEL=8 pip install --no-build-isolation . -vv \
+    --config-settings=cmake.define.Pism_CONFIG_FILE=${CONDA_PREFIX}/share/pism/pism_config.nc
+    
 - Caveat: pip's wheel-build path runs cmake --install into the staging area and
   then throws the staging away. The pism_config.nc and other configure-time files stay
   in the wheel-tag build dir, so most tests should still run — but tests that

--- a/environment.yml
+++ b/environment.yml
@@ -36,6 +36,7 @@ dependencies:
   - yac=*=*openmpi*
   - yaxt=*=*openmpi*
   - ncview
+  - wget
   # Python / analysis
   - pip
   - pip:

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   # Compilers & build tools
   - c-compiler
   - cxx-compiler
-  - cmake >=3.16
+  - cmake >=3.20
   - stdlibs
   - pkg-config
   - make
@@ -35,9 +35,13 @@ dependencies:
   - scikit-build-core
   - yac=*=*openmpi*
   - yaxt=*=*openmpi*
-  - ncview
   - wget
   # Python / analysis
+  - cdo
+  - nco
+  - ncview
+  - netcdf4 # needed for asynchronous writing
+  - xarray
   - pip
   - pip:
       - -r requirements.txt


### PR DESCRIPTION
Please describe changes proposed in this pull request.

- add pyproject.toml to allow PISM build with `pip install .` IF the prerequisites are met. For now, this is easiest within a conda environment.
- transition from `netCDF4` to `xarray` for python scripts in `examples/` but leave `tests` alone. This accidentally got merged into this branch, but I think it’s ok leave here.

If this pull request addresses an issue, please reference it here.

Note: Most pull requests should contain changes related to one specific issue or topic.

**Checklist**

- [ ] update documentation
- [ ] update [`CHANGES.rst`](CHANGES.rst)
- [ ] add regression tests
