### PR TITLE
Hole detection: fix the ocean predicates, the depth sign and the traversability seed

### DIFF
--- a/src/frontretreat/util/LabelHoleIce.cc
+++ b/src/frontretreat/util/LabelHoleIce.cc
@@ -24,6 +24,7 @@
 #include "pism/util/error_handling.hh"
 #include "pism/util/IceGrid.hh"
 #include "pism/util/IceModelVec2CellType.hh"
+#include "pism/util/Diagnostic.hh"
 
 namespace pism {
 namespace calving {
@@ -33,6 +34,24 @@ LabelHoleIce::LabelHoleIce(IceGrid::ConstPtr g)
     m_bc_open_ocean_mask(m_grid, "bc_open_ocean_mask", WITHOUT_GHOSTS),
     m_enclosed_ocean_mask(m_grid, "enclosed_ocean_mask", WITHOUT_GHOSTS)
 {
+  m_bc_open_ocean_mask.set_attrs("diagnostic",
+                                 "hole labelling seed mask: 1 where a cell is treated as"
+                                 " open ocean a priori (abyssal ocean at the domain edge,"
+                                 " or a forced-retreat point)",
+                                 "", "", "", 0);
+  m_enclosed_ocean_mask.set_attrs("diagnostic",
+                                  "hole mask: 1 where an ocean cell was identified as"
+                                  " enclosed by ice or land (a hole in an ice shelf),"
+                                  " 0 otherwise",
+                                  "", "", "", 0);
+
+  // This object is allocated even when geometry.label_holes is false, so that
+  // its diagnostics can always be named in -extra_vars. In that case update()
+  // is never called and these fields are never assigned, so zero them here:
+  // otherwise the reported values would be whatever happened to be in memory.
+  m_bc_open_ocean_mask.set(0.0);
+  m_enclosed_ocean_mask.set(0.0);
+
   m_mask_enclose_ocean_p0 = m_enclosed_ocean_mask.allocate_proc0_copy();
 }
 
@@ -61,7 +80,11 @@ void LabelHoleIce::open_ocean_mask_margin_retreat(const IceModelVec2S &bed,
 
     for (Points p(*m_grid); p; p.next()) {
       const int i = p.i(), j = p.j();
-      double depth_ocean = bed(i, j)+sea_level(i, j);
+      // Water depth, positive downward. "bed" is an elevation (negative below
+      // sea level), so the depth_abyssal/depth_coast thresholds below only make
+      // sense this way round; adding the two gives a quantity that is negative
+      // everywhere in the ocean and never exceeds depth_abyssal.
+      double depth_ocean = sea_level(i, j) - bed(i, j);
       double retreat_factor;
 
       retreat_factor = ice_area_specific_volume(i, j)/std::max(0.0001, ice_thickness(i, j));
@@ -95,7 +118,11 @@ void LabelHoleIce::open_ocean_mask_margin(const IceModelVec2S &bed,
 
     for (Points p(*m_grid); p; p.next()) {
       const int i = p.i(), j = p.j();
-      double depth_ocean = bed(i, j)+sea_level(i, j);
+      // Water depth, positive downward. "bed" is an elevation (negative below
+      // sea level), so the depth_abyssal/depth_coast thresholds below only make
+      // sense this way round; adding the two gives a quantity that is negative
+      // everywhere in the ocean and never exceeds depth_abyssal.
+      double depth_ocean = sea_level(i, j) - bed(i, j);
 
 	if (grid_edge(*m_grid, i, j) && depth_ocean > depth_abyssal) {
 	   // Abyssal ocean at the domain margin
@@ -125,11 +152,19 @@ void LabelHoleIce::update(IceModelVec2CellType &mask) {
 
     IceModelVec::AccessList list{&m_bc_open_ocean_mask, &mask, &m_enclosed_ocean_mask};
 
-    // Ocean points are potentially enclosed ocean points
+    // Ice-free ocean points are potentially enclosed ocean points.
+    //
+    // NOTE: this must be ice_free_ocean(), not ocean(). ocean() is true for
+    // floating ice too, which would make the ice shelf itself traversable by
+    // the connected-component search below: a hole would then always be
+    // "connected" to the open sea through the surrounding shelf and could never
+    // be identified as enclosed. It would also write MASK_ICE_FREE_ENCLOSED_OCEAN
+    // onto floating-ice cells, and mask 5 is ice-free as far as every predicate
+    // is concerned.
     for (Points p(*m_grid); p; p.next()) {
       const int i = p.i(), j = p.j();
 
-      if (mask.ocean(i, j) == true) {
+      if (mask.ice_free_ocean(i, j) == true) {
         m_enclosed_ocean_mask(i, j) = mask_enclosed_ocean;
       }
     }
@@ -138,7 +173,7 @@ void LabelHoleIce::update(IceModelVec2CellType &mask) {
     for (Points p(*m_grid); p; p.next()) {
       const int i = p.i(), j = p.j();
 
-      if (m_bc_open_ocean_mask(i, j) > 0.5 and mask.ocean(i, j)) {
+      if (m_bc_open_ocean_mask(i, j) > 0.5 and mask.ice_free_ocean(i, j)) {
         m_enclosed_ocean_mask(i, j) = mask_not_enclosed_ocean;
       }
     }
@@ -178,6 +213,21 @@ void LabelHoleIce::update(IceModelVec2CellType &mask) {
 
   // update ghosts of the mask
   mask.update_ghosts();
+}
+
+/*!
+ * Report both stages of the hole labelling. MASK_ICE_FREE_ENCLOSED_OCEAN itself
+ * never reaches the output file, because Geometry::ensure_consistency()
+ * recomputes cell_type after calving and GeometryCalculator only emits
+ * 0/2/3/4. Reporting these two fields instead separates the seeding from the
+ * connected-component labelling, so a failure in either stage is visible:
+ *
+ *   bc_open_ocean_mask  - which cells seeded the "this is open ocean" search
+ *   enclosed_ocean_mask - which ocean cells came out as holes
+ */
+DiagnosticList LabelHoleIce::diagnostics_impl() const {
+  return {{"bc_open_ocean_mask",  Diagnostic::wrap(m_bc_open_ocean_mask)},
+          {"enclosed_ocean_mask", Diagnostic::wrap(m_enclosed_ocean_mask)}};
 }
 
 } // end of namespace calving

--- a/src/frontretreat/util/LabelHoleIce.hh
+++ b/src/frontretreat/util/LabelHoleIce.hh
@@ -78,6 +78,10 @@ public:
 
 
 protected:
+  //! Expose the seed mask and the labelling result as diagnostics, so that both
+  //! stages can be inspected via -extra_vars. See LabelHoleIce.cc.
+  virtual DiagnosticList diagnostics_impl() const;
+
   IceModelVec2Int m_bc_open_ocean_mask;
   IceModelVec2S m_enclosed_ocean_mask;
   petsc::Vec::Ptr m_mask_enclose_ocean_p0;

--- a/src/icemodel/initialization.cc
+++ b/src/icemodel/initialization.cc
@@ -534,20 +534,30 @@ void IceModel::allocate_label_hole() {
     return;
   }
 
-  m_log->message(2,
-		 "# Allocating hole labeling in ice-free areas and floating ice (related to calving)...\n");
-
+  // NOTE: allocate unconditionally, i.e. also when geometry.label_holes is
+  // false. This submodel owns the bc_open_ocean_mask and enclosed_ocean_mask
+  // diagnostics, and PISM aborts if a name listed in -extra_vars is not
+  // available. Allocating always lets a fixed -extra_vars list mention them
+  // without forcing every run to set -label_floating_holes. The labeling itself
+  // stays gated: front_retreat_step() calls it only when the flag is set, so
+  // with the flag off both masks keep the zeros set in the constructor.
   if (m_config->get_flag("geometry.label_holes")) {
-
-    // this will throw an exception on failure
-    m_label_hole.reset(new calving::LabelHoleIce(m_grid));
-
-    // Ice shelf hole does not have a state, so it is OK to
-    // initialize here.
-    m_label_hole->init();
-
-    m_submodels["label holes in floating ice"] = m_label_hole.get();
+    m_log->message(2,
+		   "# Allocating hole labeling in ice-free areas and floating ice (related to calving)...\n");
+  } else {
+    m_log->message(2,
+		   "# Allocating hole labeling diagnostics only; geometry.label_holes is not set,"
+		   " so no labeling is done and both masks stay zero...\n");
   }
+
+  // this will throw an exception on failure
+  m_label_hole.reset(new calving::LabelHoleIce(m_grid));
+
+  // Ice shelf hole does not have a state, so it is OK to
+  // initialize here.
+  m_label_hole->init();
+
+  m_submodels["label holes in floating ice"] = m_label_hole.get();
 }
 
 void IceModel::allocate_age_model() {
@@ -674,12 +684,9 @@ void IceModel::allocate_submodels() {
   allocate_geometry_evolution();
 
   allocate_iceberg_remover();
-  if (m_config->get_flag("geometry.label_holes")) {
-    allocate_label_hole();
-  } else if (m_config->get_flag("geometry.remove_icebergs")) {
-    m_log->message(2,
-		   "# Skip allocating hole labeling in ice-free areas and floating ice ...\n");
-  }
+  // Always allocated, whether or not hole labeling is switched on: it owns
+  // diagnostics that -extra_vars may name either way. See allocate_label_hole().
+  allocate_label_hole();
 
 
   allocate_stressbalance();

--- a/src/util/IceModelVec2CellType.hh
+++ b/src/util/IceModelVec2CellType.hh
@@ -77,7 +77,7 @@ public:
   //! \brief Ocean point (area) is entirely surrounded by ice (e.g., hole in ice shelf); fallback ocean point
   inline bool ice_free_enclosed_ocean(int i, int j, bool do_consider_holes = false) const {
     if (do_consider_holes) {
-      return mask::ice_free_enclosed_ocean(as_int(i, j));
+      return mask::ice_free_enclosed_ocean(as_int(i, j), do_consider_holes);
     } else {
       return mask::ice_free_ocean(as_int(i, j));
     }
@@ -86,7 +86,7 @@ public:
   //! \brief Ocean point belongs to the open ocean (e.g., not enclosed by ice); fallback ocean point
   inline bool ice_free_open_ocean(int i, int j, bool do_consider_holes = false) const {
     if (do_consider_holes) {
-      return mask::ice_free_open_ocean(as_int(i, j));
+      return mask::ice_free_open_ocean(as_int(i, j), do_consider_holes);
     } else {
       return mask::ice_free_ocean(as_int(i, j));
     }

--- a/src/util/Mask.hh
+++ b/src/util/Mask.hh
@@ -77,7 +77,12 @@ namespace mask {
   //!        such as holes in ice shelves).
   inline bool ice_free_open_ocean(int M, bool do_consider_holes = false) {
     if (do_consider_holes) {
-      return not ice_free_enclosed_ocean(M);
+      // The cell must still BE ice-free ocean: "not enclosed" on its own is
+      // also true for grounded ice, floating ice and ice-free bedrock, none of
+      // which are open ocean. Note ice_free_ocean() is true for both
+      // MASK_ICE_FREE_OCEAN and MASK_ICE_FREE_ENCLOSED_OCEAN, so the second
+      // test is what actually excludes holes.
+      return ice_free_ocean(M) and not ice_free_enclosed_ocean(M, do_consider_holes);
     } else {
       return ice_free_ocean(M);
     }


### PR DESCRIPTION
### `Mask: fix ice_free_open_ocean and forward do_consider_holes`

- `ice_free_open_ocean(M, true)` returned `!ice_free_enclosed_ocean(M)`, which is
  also true for grounded ice, floating ice and ice-free bedrock. The cell still
  has to *be* ice-free ocean.
- `IceModelVec2CellType`'s two wrappers dropped `do_consider_holes` when
  delegating to the `mask::` free functions, so those took their default of
  `false` and fell back to plain `ice_free_ocean()`. The distinction the caller
  asked for was silently discarded.

### `LabelHoleIce: fix the depth sign and the traversability test, add diagnostics`

- **Depth sign.** `depth_ocean` was `bed + sea_level`, but `bed` is an elevation
  and is negative below sea level, so the sum is negative everywhere in the ocean
  and never exceeds `depth_abyssal`. The thresholds could not fire. Now
  `sea_level - bed`, positive downward.
- **Traversability.** The connected-component search seeded from `ocean()`, which
  includes floating ice. That makes the shelf itself traversable, so a hole is
  always "connected" to the open sea through the surrounding shelf and can never
  be enclosed. It also wrote `MASK_ICE_FREE_ENCLOSED_OCEAN` onto floating-ice
  cells, and mask 5 reads as ice-free to every predicate. Now seeds from
  `ice_free_ocean()`.
- **Diagnostics.** `MASK_ICE_FREE_ENCLOSED_OCEAN` never reaches the output file:
  `Geometry::ensure_consistency()` recomputes `cell_type` after calving and
  `GeometryCalculator` only emits 0/2/3/4. Reporting `bc_open_ocean_mask` and
  `enclosed_ocean_mask` separates seeding from labelling so a failure in either
  stage is visible.